### PR TITLE
make css properties exclusive for sliders, do icons don't get affected

### DIFF
--- a/css/VFBTermInfo.less
+++ b/css/VFBTermInfo.less
@@ -201,10 +201,10 @@
 	text-align : center;
 }
 
-[aria-hidden="true"] {
+.slick-track [aria-hidden="true"] {
     visibility : hidden !important;
 }
 
-[aria-hidden="false"] {
+.slick-track [aria-hidden="false"] {
     visibility : visible !important;
 }


### PR DESCRIPTION
Make  css properties exclusive to slider