### PR TITLE
disabling tutorial component

### DIFF
--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -1166,7 +1166,7 @@ export default class VFBMain extends React.Component {
           datasourceConfig={this.queryBuilderDatasourceConfig} />
 
         <div id="tutorialDiv">
-          {this.tutorialRender}
+          { // this.tutorialRender }
         </div>
 
         {this.htmlToolbarRender}

--- a/components/configuration/vfbtoolbarMenuConfiguration.js
+++ b/components/configuration/vfbtoolbarMenuConfiguration.js
@@ -317,14 +317,6 @@ var toolbarMenu = {
       position: "bottom-start",
       list: [
         {
-          label: "Start Tutorial",
-          icon: "",
-          action: {
-            handlerAction: "UIElementHandler",
-            parameters: ["tutorialWidgetVisible"]
-          }
-        },
-        {
           label: "F.A.Q.",
           icon: "",
           action: {


### PR DESCRIPTION
Disabling the tutorial component as discussed due to the problem related to the new history logic that does not work properly with non-react component due to the fact that those result outside the virtual DOM handled by React.