### PR TITLE
refactored instance handler to visualize info in the tree and term in…

### DIFF
--- a/components/interface/FocusTerm.js
+++ b/components/interface/FocusTerm.js
@@ -335,8 +335,9 @@ export default class FocusTerm extends React.Component {
 
   componentDidMount () {
     GEPPETTO.on(GEPPETTO.Events.Select, function (instance) {
-      console.log('Selection of ' + instance.getName());
-      if (instance[instance.getId() + "_meta"] !== undefined && instance.getName() !== this.state.currentInstance.getName()) {
+      if (this.state.currentInstance === undefined && instance[instance.getId() + "_meta"] !== undefined) {
+        this.setInstance(instance[instance.getId() + "_meta"]);
+      } else if (instance[instance.getId() + "_meta"] !== undefined && instance.getName() !== this.state.currentInstance.getName()) {
         this.setInstance(instance[instance.getId() + "_meta"]);
       }
     }.bind(this));


### PR DESCRIPTION
- refactored the way we were handling the termInfo (and also tree browser) instance update, now handled by a single handler function that has all the logic inside.
- The same handler takes care of the id= and i= logic, basically the id= is placed as last item in the array this.idsFromURL, if the length of this array is bigger than 0 we don't add these instances to the term info and tree, unless the id is equal to idFromURL that contains the id= instance.
This check is done until this array length is bigger than 0, so basically only on startup, when the array has been emptied we don't consider this logic anymore.
- Removed redundant calls to set the termInfo in different points.
- Added the selection to the window.resolve3D call in the callback function (not present before).