### PR TITLE
Tree browser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG targetBranch=development
 ARG originBranch=development
 ARG defaultBranch=development
 
-ARG mvnOpt="-X -Dhttps.protocols=TLSv1.2 -DskipTests --quiet -Pmaster"
+ARG mvnOpt="-Dhttps.protocols=TLSv1.2 -DskipTests --quiet -Pmaster"
 
 ARG googleAnalyticsSiteCode=UA-45841517-1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG targetBranch=development
 ARG originBranch=development
 ARG defaultBranch=development
 
-ARG mvnOpt="-Dhttps.protocols=TLSv1.2 -DskipTests --quiet -Pmaster"
+ARG mvnOpt="-X -Dhttps.protocols=TLSv1.2 -DskipTests --quiet -Pmaster"
 
 ARG googleAnalyticsSiteCode=UA-45841517-1
 

--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -47,6 +47,7 @@ export default class VFBMain extends React.Component {
       idSelected: undefined
     };
 
+    this.addVfbId = this.addVfbId.bind(this);
     this.menuHandler = this.menuHandler.bind(this);
     this.setWrapperRef = this.setWrapperRef.bind(this);
     this.htmlToolbarRef = this.htmlToolbarRef.bind(this);
@@ -786,7 +787,8 @@ export default class VFBMain extends React.Component {
           id="treeWidget"
           instance={this.instanceOnFocus}
           size={{ height: _height, width: _width }}
-          ref={ref => this.treeBrowserReference = ref}/>
+          ref={ref => this.treeBrowserReference = ref}
+          selectionHandler={this.addVfbId}/>
       </div>);
     }
   }

--- a/components/configuration/treeWidgetConfiguration.js
+++ b/components/configuration/treeWidgetConfiguration.js
@@ -1,0 +1,22 @@
+var restPostConfig = {
+  url: "http://pdb.virtualflybrain.org/db/data/transaction/commit",
+  contentType: "application/json"
+};
+
+var treeCypherQuery = instance => ({
+  "statements": [
+    {
+      "statement": "MATCH (root:Class)<-[:INSTANCEOF]-(t:Individual {short_form:'" + instance + "'})"
+      + "<-[:depicts]-(tc:Individual)<-[ie:in_register_with]-(c:Individual)-[:depicts]->(image:"
+      + "Individual)-[r:INSTANCEOF]->(anat:Class) WHERE has(ie.index) WITH root, anat,r,image"
+      + " MATCH p=allShortestPaths((root)<-[:SUBCLASSOF|part_of*..]-(anat:Class)) RETURN p,r,image",
+      "resultDataContents": ["graph"]
+    }
+  ]
+});
+
+
+module.exports = {
+  restPostConfig,
+  treeCypherQuery
+};

--- a/components/interface/TreeWidget.js
+++ b/components/interface/TreeWidget.js
@@ -55,7 +55,7 @@ export default class TreeWidget extends React.Component {
       left_second_column: 395,
       column_width_small: 385,
       column_width_viewer: "calc(100% - 385px)",
-      row_height: 30,
+      row_height: 25,
       top: 0,
       height: this.props.size.height,
       width: this.props.size.width
@@ -99,23 +99,23 @@ export default class TreeWidget extends React.Component {
   sortData (unsortedArray, key, comparator) {
     // Create a sortable array to return.
     const sortedArray = [ ...unsortedArray ];
-  
+
     // Recursively sort sub-arrays.
     const recursiveSort = (start, end) => {
-  
+
       // If this sub-array is empty, it's sorted.
       if (end - start < 1) {
         return;
       }
-  
+
       const pivotValue = sortedArray[end];
       let splitIndex = start;
       for (let i = start; i < end; i++) {
         const sort = comparator(sortedArray[i], pivotValue, key);
-  
+
         // This value is less than the pivot value.
         if (sort === -1) {
-  
+
           /*
            * If the element just to the right of the split index,
            *   isn't this element, swap them.
@@ -125,29 +125,29 @@ export default class TreeWidget extends React.Component {
             sortedArray[splitIndex] = sortedArray[i];
             sortedArray[i] = temp;
           }
-  
+
           /*
            * Move the split index to the right by one,
            *   denoting an increase in the less-than sub-array size.
            */
           splitIndex++;
         }
-  
+
         /*
          * Leave values that are greater than or equal to
          *   the pivot value where they are.
          */
       }
-  
+
       // Move the pivot value to between the split.
       sortedArray[end] = sortedArray[splitIndex];
       sortedArray[splitIndex] = pivotValue;
-  
+
       // Recursively sort the less-than and greater-than arrays.
       recursiveSort(start, splitIndex - 1);
       recursiveSort(splitIndex + 1, end);
     };
-  
+
     // Sort the entire array.
     recursiveSort(0, unsortedArray.length - 1);
     return sortedArray;
@@ -385,7 +385,7 @@ export default class TreeWidget extends React.Component {
   findRoot (nodes) {
     let min = nodes[0].id;
     for ( let i = 1; i < nodes.length; i++) {
-      if(nodes[i].id < min) {
+      if (nodes[i].id < min) {
         min = nodes[i].id;
       }
     }
@@ -426,10 +426,10 @@ export default class TreeWidget extends React.Component {
         onClick={ () => {
           this.setState({ displayColorPicker: true });
         }}>
-        { (this.state.displayColorPicker 
+        { (this.state.displayColorPicker
           && this.state.nodeSelected.subtitle === rowInfo.node.subtitle
-          && this.colorPickerNode === undefined) 
-          ? <CompactColor 
+          && this.colorPickerNode === undefined)
+          ? <CompactColor
             style={{ zIndex: 10 }}/>
           : null}
       </i>);
@@ -448,14 +448,14 @@ export default class TreeWidget extends React.Component {
               <img id="dario"
                 src={"https://VirtualFlyBrain.org/reports/" + rowInfo.node.instanceId + "/thumbnailT.png"} />
             </div></div>}>
-          <div 
+          <div
             className={rowInfo.node.subtitle === this.state.nodeSelected.subtitle
-              ? "nodeFound nodeSelected" 
+              ? "nodeFound nodeSelected"
               : "nodeSelected"}
             onClick={ () => {
               this.colorPickerNode = undefined;
               this.props.selectionHandler(rowInfo.node.subtitle);
-              this.setState({ displayColorPicker: false }); 
+              this.setState({ displayColorPicker: false });
             }}>
             {rowInfo.node.title}
           </div>

--- a/css/VFBMain.less
+++ b/css/VFBMain.less
@@ -1355,7 +1355,7 @@
   .rst__collapseButton:focus,
   .rst__expandButton:focus {
     outline: none;
-    box-shadow: 0 0 0 1px #000, 0 0 1px 3px #83bef9;
+    box-shadow: none; //0 0 0 1px #000, 0 0 1px 3px #83bef9;
   }
   .rst__collapseButton:hover:not(:active),
   .rst__expandButton:hover:not(:active) {
@@ -1615,7 +1615,9 @@
 }
 
 .nodeFound {
-  outline: solid 3px #0080ff;
+  //outline: solid 3px #0080ff;
+  color: #0080ff;
+
 }
 
 .chrome-picker {

--- a/css/VFBMain.less
+++ b/css/VFBMain.less
@@ -1341,8 +1341,8 @@
     position: absolute;
     border-radius: 100%;
     box-shadow: 0 0 0 1px #000;
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
     padding: 0;
     top: 50%;
     transform: translate(-50%, -50%);
@@ -1549,7 +1549,7 @@
 
 // Tree component styling
 .rst__rowContents {
-    background: rgb(25, 25, 25);
+    background: transparent;
     color: #ffffff;
     cursor: pointer;
     border-bottom: 1px solid rgb(25, 25, 25);
@@ -1607,7 +1607,7 @@
   font-size: 14px;
   font-family: 'Khand', sans-serif;
   border: 0px solid;
-  background: #191919;
+  background: transparent;
 }
 
 .nodeSelected:hover {

--- a/css/VFBMain.less
+++ b/css/VFBMain.less
@@ -1124,7 +1124,7 @@
    * Nodes matching the search conditions are highlighted
    */
   .rst__rowSearchMatch {
-    outline: solid 3px #0080ff;
+    //outline: solid 3px #0080ff;
   }
   
   /**
@@ -1603,17 +1603,22 @@
   }
 
 .nodeSelected {
-  color: #11bffe;
+  color: #ffffff;
   font-size: 14px;
   font-family: 'Khand', sans-serif;
   border: 0px solid;
   background: #191919;
 }
 
-.nodeUnselected {
-  color: #ffffff;
-  font-size: 12px;
-  font-family: 'Khand', sans-serif;
-  border: 0px solid;
-  background: #191919;
+.nodeSelected:hover {
+  color: #11bffe;
+}
+
+.nodeFound {
+  outline: solid 3px #0080ff;
+}
+
+.chrome-picker {
+  position: absolute;
+  z-index: 1;
 }

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
     "start": "node --max_old_space_size=2048 node_modules/webpack-dev-server/bin/webpack-dev-server.js --progress  --config webpack.config.dev.js"
   },
   "dependencies": {
-    "@geppettoengine/geppetto-client": "file:./geppetto-client",
     "@babel/core": "^7.4.5",
+    "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
-    "@babel/plugin-proposal-class-properties": "^7.1.0",
+    "@geppettoengine/geppetto-client": "file:./geppetto-client",
+    "@material-ui/icons": "3.0.1",
     "babel-loader": "^8.0.6",
     "copy-webpack-plugin": "^4.6.0",
     "css-loader": "^3.0.0",
@@ -32,13 +33,13 @@
     "imports-loader": "^0.7.1",
     "less-loader": "^5.0.0",
     "mini-css-extract-plugin": "^0.7.0",
+    "react-collapsible": "^2.3.1",
+    "react-color": "^2.17.3",
+    "react-tabs": "3.0.0",
     "style-loader": "^0.13.2",
     "url-loader": "^0.5.8",
     "webpack": "4.35.0",
-    "webpack-cli": "^3.3.5",
-    "@material-ui/icons": "3.0.1",
-    "react-collapsible": "^2.3.1",
-    "react-tabs": "3.0.0"
+    "webpack-cli": "^3.3.5"
   },
   "devDependencies": {
     "@babel/preset-stage-2": "^7.0.0",


### PR DESCRIPTION
- [x] Cypher query factored out in configuration file
- [x] change onClick behaviour, remove the i-info and if you click on label it will display on the term info, the arrows instead will drive the navigation.
- [x] Label will show tooltip with the thumbnail, remove the info icon.
- [x] vertical size of the boxes to be reduced.
- [x] Color picker to be included.
- [x] Checkbox to add individual to be added (eye icon to be in line with other components).
- [x] expand on instance selection not working (works for classes, need to discuss this in the sprint)
- [ ] If focus term = Type or anat_ind -> open tree to corresponding node(s)