### PR TITLE
id= and i= disabling the quickhelp

### DIFF
--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -82,6 +82,7 @@ export default class VFBMain extends React.Component {
     this.urlQueryLoader = undefined;
     this.quickHelpRender = undefined;
     this.firstLoad = true;
+    this.quickHelpOpen = true;
 
     this.UIElementsVisibility = {};
 
@@ -933,7 +934,10 @@ export default class VFBMain extends React.Component {
     // Retrieve cookie for 'quick_help' modal
     var cookie = getCookie("show_quick_help");
     // Show 'Quick Help' modal if cookie to hide it is not set to True
-    if ( cookie !== "1") {
+    if ((this.props.location.search.indexOf("id=") > -1) || (this.props.location.search.indexOf("i=") > -1)) {
+      this.quickHelpOpen = false;
+    }
+    if (( cookie !== "1") && (this.quickHelpOpen)) {
       this.quickHelpRender = <VFBQuickHelp id="quickHelp" closeQuickHelp={this.closeQuickHelp} />;
     }
   }


### PR DESCRIPTION
as per title, when i= or id= is used the quickhelp is not displayed not matter the check on the cookie.