### PR TITLE
#984 - Context browser - sync behaviour broken 

### DIFF
--- a/components/interface/VFBGraph/VFBGraph.js
+++ b/components/interface/VFBGraph/VFBGraph.js
@@ -266,8 +266,7 @@ class VFBGraph extends Component {
    * Handle Left click on Nodes
    */
   handleNodeLeftClick (node, event) {
-    this.nodeSelectedID = node.title;
-    this.queryNewInstance(node);
+    window.addVfbId(node.title)
   }
 
   /**


### PR DESCRIPTION
#984 selection of Term Context node triggers addVFBID and changes UI, but doesn't update the Term Context component unless user presses sync button
