### PR TITLE
Feature/727 - Term Info section collapse/expand

### DIFF
--- a/components/interface/VFBTermInfo/VFBTermInfo.js
+++ b/components/interface/VFBTermInfo/VFBTermInfo.js
@@ -19,21 +19,6 @@ const CIRCUIT_BROWSER = "CircuitBrowser";
 
 require('../../../css/VFBTermInfo.less');
 
-class CollapsibleTitle extends React.Component {
-  handleClick (event) {
-    event.stopPropagation();
-    event.preventDefault()
-  }
-  
-  render () {
-    return (
-      <p className="collapsibleTitle" onClick={this.handleClick}>
-        {this.props.title}
-      </p>
-    );
-  }
-}
-
 class VFBTermInfo extends React.Component {
 
   constructor (props) {
@@ -232,7 +217,7 @@ class VFBTermInfo extends React.Component {
       if (counter !== undefined) {
         prevCounter = counter;
       }
-      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={<CollapsibleTitle title={this.contentTermInfo.keys[prevCounter]}/>}>
+      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={this.contentTermInfo.keys[prevCounter]}>
         <div>
           <HTMLViewer id={id} content={value.html} />
         </div>
@@ -243,7 +228,7 @@ class VFBTermInfo extends React.Component {
       if (counter !== undefined) {
         prevCounter = counter;
       }
-      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={<CollapsibleTitle title={this.contentTermInfo.keys[prevCounter]}/>}>
+      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={this.contentTermInfo.keys[prevCounter]}>
         <div>
           <HTMLViewer id={id} content={anchorme(value.text, anchorOptions)} />
         </div>
@@ -283,7 +268,7 @@ class VFBTermInfo extends React.Component {
             lazyLoad: "progressive",
             afterChange: current => (this.hookupImages(current))
           };
-          this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={<CollapsibleTitle title={this.contentTermInfo.keys[prevCounter]}/>}>
+          this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={this.contentTermInfo.keys[prevCounter]}>
             <Slider {...settings}>
               {elements.map((element, key) => {
                 var Element = React.cloneElement(element);
@@ -300,7 +285,7 @@ class VFBTermInfo extends React.Component {
         } else if (value.eClass == GEPPETTO.Resources.IMAGE) {
           // otherwise we just show an image
           var image = value;
-          this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={<CollapsibleTitle title={this.contentTermInfo.keys[prevCounter]}/>}>
+          this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={this.contentTermInfo.keys[prevCounter]}>
             <div className="popup-image">
               <a href={location.protocol + '//' + location.host + location.pathname + "/" + image.reference} onClick={event => {
                 event.stopPropagation();
@@ -330,7 +315,7 @@ class VFBTermInfo extends React.Component {
         );
       }
       
-      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={<CollapsibleTitle title={this.contentTermInfo.keys[prevCounter]}/>}>
+      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={this.contentTermInfo.keys[prevCounter]}>
         {graphs.map((graph, key) => {
           var Element = React.cloneElement(graph);
           /*
@@ -359,7 +344,7 @@ class VFBTermInfo extends React.Component {
         );
       }
         
-      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={<CollapsibleTitle title={this.contentTermInfo.keys[prevCounter]}/>}>
+      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={this.contentTermInfo.keys[prevCounter]}>
         {graphs.map((graph, key) => {
           var Element = React.cloneElement(graph);
           /*

--- a/components/interface/VFBTermInfo/VFBTermInfo.js
+++ b/components/interface/VFBTermInfo/VFBTermInfo.js
@@ -19,6 +19,21 @@ const CIRCUIT_BROWSER = "CircuitBrowser";
 
 require('../../../css/VFBTermInfo.less');
 
+class CollapsibleTitle extends React.Component {
+  handleClick (event) {
+    event.stopPropagation();
+    event.preventDefault()
+  }
+  
+  render () {
+    return (
+      <p className="collapsibleTitle" onClick={this.handleClick}>
+        {this.props.title}
+      </p>
+    );
+  }
+}
+
 class VFBTermInfo extends React.Component {
 
   constructor (props) {
@@ -217,7 +232,7 @@ class VFBTermInfo extends React.Component {
       if (counter !== undefined) {
         prevCounter = counter;
       }
-      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={this.contentTermInfo.keys[prevCounter]}>
+      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={<CollapsibleTitle title={this.contentTermInfo.keys[prevCounter]}/>}>
         <div>
           <HTMLViewer id={id} content={value.html} />
         </div>
@@ -228,7 +243,7 @@ class VFBTermInfo extends React.Component {
       if (counter !== undefined) {
         prevCounter = counter;
       }
-      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={this.contentTermInfo.keys[prevCounter]}>
+      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={<CollapsibleTitle title={this.contentTermInfo.keys[prevCounter]}/>}>
         <div>
           <HTMLViewer id={id} content={anchorme(value.text, anchorOptions)} />
         </div>
@@ -268,7 +283,7 @@ class VFBTermInfo extends React.Component {
             lazyLoad: "progressive",
             afterChange: current => (this.hookupImages(current))
           };
-          this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={this.contentTermInfo.keys[prevCounter]}>
+          this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={<CollapsibleTitle title={this.contentTermInfo.keys[prevCounter]}/>}>
             <Slider {...settings}>
               {elements.map((element, key) => {
                 var Element = React.cloneElement(element);
@@ -285,7 +300,7 @@ class VFBTermInfo extends React.Component {
         } else if (value.eClass == GEPPETTO.Resources.IMAGE) {
           // otherwise we just show an image
           var image = value;
-          this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={this.contentTermInfo.keys[prevCounter]}>
+          this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={<CollapsibleTitle title={this.contentTermInfo.keys[prevCounter]}/>}>
             <div className="popup-image">
               <a href={location.protocol + '//' + location.host + location.pathname + "/" + image.reference} onClick={event => {
                 event.stopPropagation();
@@ -315,7 +330,7 @@ class VFBTermInfo extends React.Component {
         );
       }
       
-      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={this.contentTermInfo.keys[prevCounter]}>
+      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={<CollapsibleTitle title={this.contentTermInfo.keys[prevCounter]}/>}>
         {graphs.map((graph, key) => {
           var Element = React.cloneElement(graph);
           /*
@@ -344,7 +359,7 @@ class VFBTermInfo extends React.Component {
         );
       }
         
-      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={this.contentTermInfo.keys[prevCounter]}>
+      this.contentTermInfo.values[prevCounter] = (<Collapsible open={true} trigger={<CollapsibleTitle title={this.contentTermInfo.keys[prevCounter]}/>}>
         {graphs.map((graph, key) => {
           var Element = React.cloneElement(graph);
           /*

--- a/css/VFBTermInfo.less
+++ b/css/VFBTermInfo.less
@@ -188,6 +188,14 @@
     background-color: grey;
 }
 
+.collapsibleTitle {
+    margin : 0 !important;
+}
+
+.collapsibleTitle:hover {
+    cursor : auto;
+}
+
 .CustomTriggerCSS {
     background-color: lightcoral;
     transition: background-color 200ms ease;

--- a/css/VFBTermInfo.less
+++ b/css/VFBTermInfo.less
@@ -190,14 +190,6 @@
     background-color: grey;
 }
 
-.collapsibleTitle {
-    margin : 0 !important;
-}
-
-.collapsibleTitle:hover {
-    cursor : auto;
-}
-
 .CustomTriggerCSS {
     background-color: lightcoral;
     transition: background-color 200ms ease;

--- a/css/VFBTermInfo.less
+++ b/css/VFBTermInfo.less
@@ -166,6 +166,7 @@
     background: transparent;
     cursor: pointer;
     font-family: 'Barlow Condensed', 'Khand', sans-serif;
+    pointer-events: none !important;
 }
 
 .Collapsible__trigger:after {
@@ -176,6 +177,7 @@
     top: 10px;
     display: block;
     transition: transform 300ms;
+    pointer-events: auto !important;
 }
 
 .Collapsible__trigger.is-open:after {


### PR DESCRIPTION
Term info sections only expand/collapse when clicking on the expand/collapse icon, no longer when clicking on the text.
