### PR TITLE
#1322 Label and id in squared brackets in the node float over/tooltip

### DIFF
--- a/components/interface/VFBCircuitBrowser/VFBCircuitBrowser.js
+++ b/components/interface/VFBCircuitBrowser/VFBCircuitBrowser.js
@@ -408,7 +408,7 @@ class VFBCircuitBrowser extends Component {
             data={this.state.graph}
             // Create the Graph as 2 Dimensional
             d2={true}
-            nodeLabel={node => node.title}
+            nodeLabel={node => node.name + "[" + node.title + "]"}
             // Relationship label, placed in Link
             linkLabel={link => link.label}
             // Width of links, log(weight)


### PR DESCRIPTION
Label and id in squared brackets in the node float over/tooltip

![image](https://user-images.githubusercontent.com/4562825/160208248-eadb9eb3-ed8b-49bd-8cf0-edbadc15c47a.png)

