### PR TITLE
Add GA pageview tracking for query link clicks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG geppettoDatasourceRelease=VFBv2.3.4
 ARG geppettoModelSwcRelease=v1.0.1
 ARG geppettoFrontendRelease=VFBv2.1.0.7
 ARG geppettoClientRelease=VFBv2.2.10
-ARG ukAcVfbGeppettoRelease=v2.2.4.9
+ARG ukAcVfbGeppettoRelease=v2.2.4.10
 
 ARG mvnOpt="-Dhttps.protocols=TLSv1.2 -DskipTests --quiet -Pmaster"
 

--- a/components/interface/VFBTermInfo/VFBTermInfo.js
+++ b/components/interface/VFBTermInfo/VFBTermInfo.js
@@ -443,10 +443,11 @@ class VFBTermInfo extends React.Component {
         if (metaType === undefined || (metaType !== undefined && node !== undefined && node.getMetaType() === metaType)) {
         // hookup custom handler
           var that = this;
+          var href = $(that).attr('href');
           $(that).off();
           $(that).on(ev, function () {
           // invoke custom handler with instancepath as arg
-            fun(node, path, popup);
+            fun(node, path, popup, href);
             // stop default event handler of the anchor from doing anything
             return false;
           });
@@ -720,7 +721,7 @@ class VFBTermInfoWidget extends React.Component {
   }
 
 
-  customHandler (node, path, widget) {
+  customHandler (node, path, widget, href) {
     try {
       // handling path consisting of a list. Note: first ID is assumed to be the template followed by a single ID (comma separated) 
       if (path.indexOf("[") == 0) {
@@ -820,6 +821,12 @@ class VFBTermInfoWidget extends React.Component {
         if (typeof (entity) != 'undefined' && entity instanceof Query) {
           // clear query builder unless ctrl pressed them add to compound.
           console.log('Query requested: ' + path + " " + otherName);
+          // Send GA pageview for query using the original link href
+          if (href) {
+            window.ga('vfb.send', 'pageview', href);
+          } else {
+            window.ga('vfb.send', 'pageview', (window.location.pathname + '?q=' + otherId + ',' + path));
+          }
           GEPPETTO.trigger('spin_logo');
 
           this.props.queryBuilder.open();


### PR DESCRIPTION
## Summary

Adds Google Analytics pageview tracking when a user clicks a query link in VFBTermInfo (e.g. "Neurons with some part in medulla", "Subclasses of medulla", etc.).

## Changes

**`components/interface/VFBTermInfo/VFBTermInfo.js`**

- **`hookupCustomHandler`**: Captures the `href` attribute from the `<a>` element and passes it as a 4th argument to the click handler function.
- **`customHandler`**: Accepts the new `href` parameter and sends a `window.ga('vfb.send', 'pageview', ...)` event when a query is executed, using the original link href (e.g. `/org.geppetto.frontend/geppetto?q=FBbt_00003748,NeuronsPartHere`). Falls back to constructing the URL from `otherId` and `path` when `href` is not available.

## Motivation

Query link clicks were not being tracked in Google Analytics. Other interactions like term info page changes and template switches already send pageview/event data. This change ensures query usage is also tracked, matching the existing pageview pattern used elsewhere (e.g. in `VFBFocusTerm.js`).