### PR TITLE
Class-connectivity: include focus term in OWLERY->Solr step

### DIFF
--- a/model/queries_execution_notebook.ipynb
+++ b/model/queries_execution_notebook.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3e8bfba6",
+   "id": "ee3b51d4",
    "metadata": {},
    "source": [
     "# Query Execution Notebook"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b4241d31",
+   "id": "23026825",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9b8b10e",
+   "id": "5059c5ca",
    "metadata": {},
    "source": [
     "## anatomy_query\n",
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0e2f098",
+   "id": "a28a730a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd4c1599",
+   "id": "2eebb23b",
    "metadata": {},
    "source": [
     "## anat_image_query\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ad0b3db",
+   "id": "6b6ce7cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2081c36c",
+   "id": "7c9d06b3",
    "metadata": {},
    "source": [
     "## Get other cluster members\n",
@@ -104,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "547e6b1b",
+   "id": "719a125b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9efbf5f",
+   "id": "701854a3",
    "metadata": {},
    "source": [
     "## Fetch all example individuals for Class\n",
@@ -141,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0e6ba8a",
+   "id": "d14674f6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e30bb3b1",
+   "id": "c8dcbf21",
    "metadata": {},
    "source": [
     "## Find domain individuals for template id\n",
@@ -178,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f7aac44",
+   "id": "99d51150",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c36bb555",
+   "id": "429f0472",
    "metadata": {},
    "source": [
     "## Get cluster members\n",
@@ -215,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33e5f917",
+   "id": "bb56a1b0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5764762",
+   "id": "ce9099ea",
    "metadata": {},
    "source": [
     "## Find images for dataset\n",
@@ -252,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77015de5",
+   "id": "4b926f63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c620749a",
+   "id": "55f23e06",
    "metadata": {},
    "source": [
     "## Test Query for Exp from Anatomy\n",
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f367ae0",
+   "id": "69a9b985",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b465a324",
+   "id": "1290ce4f",
    "metadata": {},
    "source": [
     "## Query for Anatomy from Exp\n",
@@ -326,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8abd8632",
+   "id": "2cc38bc7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ca97930",
+   "id": "74520e95",
    "metadata": {},
    "source": [
     "## Test Query for Anatomy from Exp\n",
@@ -363,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aafe487c",
+   "id": "9a7e15bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea10ef9c",
+   "id": "6e5d6bf6",
    "metadata": {},
    "source": [
     "## Query for Exp from Anatomy\n",
@@ -400,7 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5bdf7d64",
+   "id": "47e68cf5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +427,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5d580e5",
+   "id": "4216e72b",
    "metadata": {},
    "source": [
     "## test_all_datasets_query\n",
@@ -437,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c7f2a9db",
+   "id": "0a0cf590",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +464,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53b2e995",
+   "id": "f2fed3bd",
    "metadata": {},
    "source": [
     "## Query for Exp from Anatomy\n",
@@ -474,7 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7d5201e",
+   "id": "46958e6a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +501,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a15ce35",
+   "id": "a4a6def4",
    "metadata": {},
    "source": [
     "## neuron_region_connectivity_query\n",
@@ -511,7 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44d91252",
+   "id": "3c2f1b75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +538,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c18cf848",
+   "id": "c9268d2b",
    "metadata": {},
    "source": [
     "## neuron_neuron_connectivity_query\n",
@@ -548,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36fa9404",
+   "id": "fe8d3431",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -575,7 +575,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c293032e",
+   "id": "b0ccce19",
    "metadata": {},
    "source": [
     "## NBLAST_anat_image_query\n",
@@ -585,7 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5438b0a6",
+   "id": "682bdfba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -612,7 +612,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fdaf15f",
+   "id": "8873fbf2",
    "metadata": {},
    "source": [
     "## Fetch all entities for pub\n",
@@ -622,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7cdc30ab",
+   "id": "a909029a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -649,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba92e0b1",
+   "id": "7a7fe371",
    "metadata": {},
    "source": [
     "## NBLAST_anat_image_query_exp\n",
@@ -659,7 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e265c5f3",
+   "id": "16a9756e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +686,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10147fd5",
+   "id": "de28937c",
    "metadata": {},
    "source": [
     "## NB_anat_image_query\n",
@@ -696,7 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b61f7fb8",
+   "id": "bb7618ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -723,7 +723,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d46ff12",
+   "id": "c59237d2",
    "metadata": {},
    "source": [
     "## Get JSON for cluster expression query\n",
@@ -733,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a7ad5c4",
+   "id": "f6869aea",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -760,7 +760,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1de88316",
+   "id": "0ce9aeca",
    "metadata": {},
    "source": [
     "## Get JSON for anat scRNAseq query\n",
@@ -770,7 +770,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa27c042",
+   "id": "154280ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -797,7 +797,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ab64b8d",
+   "id": "35b774d9",
    "metadata": {},
    "source": [
     "## Get JSON for dataset scRNAseq query\n",
@@ -807,7 +807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4785c3e",
+   "id": "cd85a63b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -834,7 +834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a08f78da",
+   "id": "da91ebfd",
    "metadata": {},
    "source": [
     "## Get JSON for cluster expression query\n",
@@ -844,7 +844,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd139f08",
+   "id": "df761a6b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -871,7 +871,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54efbaf9",
+   "id": "85b706ec",
    "metadata": {},
    "source": [
     "## Get term core info\n",
@@ -881,7 +881,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6711c19",
+   "id": "a1481a9c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -908,7 +908,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e75cdb3",
+   "id": "3bc12ace",
    "metadata": {},
    "source": [
     "## Get baseline term info\n",
@@ -918,7 +918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8cb5330",
+   "id": "6c85ed3f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -945,7 +945,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7093a642",
+   "id": "279f1f7a",
    "metadata": {},
    "source": [
     "## Get JSON for Class\n",
@@ -955,7 +955,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c116fdaf",
+   "id": "491f0e0c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -982,7 +982,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6611223",
+   "id": "312c36bf",
    "metadata": {},
    "source": [
     "## Get JSON for Neuron Class\n",
@@ -992,7 +992,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a6e3dec",
+   "id": "26f8e0e5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1019,7 +1019,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aec362dd",
+   "id": "3d488292",
    "metadata": {},
    "source": [
     "## Get JSON for Split Class\n",
@@ -1029,7 +1029,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5598ed4f",
+   "id": "32d8c163",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,7 +1056,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0405533",
+   "id": "735c15a8",
    "metadata": {},
    "source": [
     "## Get JSON for Individual\n",
@@ -1066,7 +1066,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aebd2cb9",
+   "id": "de4d050f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1093,7 +1093,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a97082a",
+   "id": "3ad822bd",
    "metadata": {},
    "source": [
     "## Get JSON for Cluster\n",
@@ -1103,7 +1103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3516c60a",
+   "id": "836af368",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1130,7 +1130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0dc00b28",
+   "id": "8e5ca1cf",
    "metadata": {},
    "source": [
     "## Get JSON for Template\n",
@@ -1140,7 +1140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b51dfd85",
+   "id": "d8938563",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1167,7 +1167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57494f25",
+   "id": "62ccfd15",
    "metadata": {},
    "source": [
     "## Get JSON for pub\n",
@@ -1177,7 +1177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4964beb2",
+   "id": "ed3bbc5d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1204,7 +1204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c36a9de",
+   "id": "78b467ef",
    "metadata": {},
    "source": [
     "## Get JSON for DataSet\n",
@@ -1214,7 +1214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "965875fb",
+   "id": "936e8126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1241,7 +1241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f5a33e0",
+   "id": "92d50e28",
    "metadata": {},
    "source": [
     "## Get JSON for License\n",
@@ -1251,7 +1251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50c926f3",
+   "id": "11566983",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,7 +1278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c0fa7d5",
+   "id": "7ebe19e0",
    "metadata": {},
    "source": [
     "## Find images aligned to template id\n",
@@ -1288,7 +1288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba959237",
+   "id": "eb7a20e0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1315,7 +1315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9c0893f",
+   "id": "a7f522b2",
    "metadata": {},
    "source": [
     "## template_2_datasets_ids\n",
@@ -1325,7 +1325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd903651",
+   "id": "b09b13a0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1352,7 +1352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48410313",
+   "id": "51f44de6",
    "metadata": {},
    "source": [
     "## all_datasets_ids\n",
@@ -1362,7 +1362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2303027b",
+   "id": "c37339f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1389,7 +1389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7407e375",
+   "id": "8d5fd811",
    "metadata": {},
    "source": [
     "## Find image ids for dataset\n",
@@ -1399,7 +1399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7b97cdf",
+   "id": "c22de26a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1426,7 +1426,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f84448b7",
+   "id": "f264c649",
    "metadata": {},
    "source": [
     "## Find images develops_from id\n",
@@ -1436,7 +1436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c16f923",
+   "id": "7bde62fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1463,7 +1463,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "266ec6d7",
+   "id": "a1fbfec0",
    "metadata": {},
    "source": [
     "## Find term ids ref in pub\n",
@@ -1473,7 +1473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "489b35e9",
+   "id": "068df167",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1500,7 +1500,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d5f1ea3",
+   "id": "a3e6d998",
    "metadata": {},
    "source": [
     "## Owlery Part of\n",
@@ -1510,7 +1510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2cd992c",
+   "id": "062ed6f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1533,7 +1533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea811adc",
+   "id": "9362803f",
    "metadata": {},
    "source": [
     "## Owlery Neuron class with part here\n",
@@ -1543,7 +1543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ecf4c91",
+   "id": "c99105f0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1566,7 +1566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5138ef0",
+   "id": "2f31626d",
    "metadata": {},
    "source": [
     "## Owlery Neurons Synaptic\n",
@@ -1576,7 +1576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d174f51",
+   "id": "2d887019",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1599,7 +1599,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac7b6011",
+   "id": "6150b7b3",
    "metadata": {},
    "source": [
     "## Owlery Neurons Presynaptic\n",
@@ -1609,7 +1609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9f5ea39",
+   "id": "40332dd1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1632,7 +1632,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ada0f139",
+   "id": "0d090887",
    "metadata": {},
    "source": [
     "## Owlery Neurons Postsynaptic\n",
@@ -1642,7 +1642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0fdbecf5",
+   "id": "38764389",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1665,7 +1665,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8041ec1d",
+   "id": "765b74a3",
    "metadata": {},
    "source": [
     "## Owlery Neuron classes fasciculating here\n",
@@ -1675,7 +1675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "596e6163",
+   "id": "b2c60f37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1698,7 +1698,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7460a4c",
+   "id": "6ed16c0e",
    "metadata": {},
    "source": [
     "## Owlery tracts in\n",
@@ -1708,7 +1708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6bb18e7c",
+   "id": "e6239f16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1731,7 +1731,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c93596a",
+   "id": "fa25ca03",
    "metadata": {},
    "source": [
     "## Owlery Subclasses of\n",
@@ -1741,7 +1741,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb2c4f57",
+   "id": "31b115d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1764,7 +1764,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4884c739",
+   "id": "1bab5410",
    "metadata": {},
    "source": [
     "## Owlery Lineage Clones\n",
@@ -1774,7 +1774,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df057ed4",
+   "id": "367cdf00",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1797,7 +1797,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "905a9dc9",
+   "id": "543ce99a",
    "metadata": {},
    "source": [
     "## subClassOf cell that overlaps some X\n",
@@ -1807,7 +1807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a694ff3",
+   "id": "0a1c15f3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1830,7 +1830,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76d5c8d1",
+   "id": "b9714f18",
    "metadata": {},
    "source": [
     "## subClassOf overlaps some X\n",
@@ -1840,7 +1840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91d210bf",
+   "id": "c944dc39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1863,7 +1863,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e465bb1",
+   "id": "312b1a44",
    "metadata": {},
    "source": [
     "## subClassOf cell overlaps some X\n",
@@ -1873,7 +1873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf0974f9",
+   "id": "12befe9b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1896,7 +1896,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4576619f",
+   "id": "27cfa61a",
    "metadata": {},
    "source": [
     "## Owlery Images of neurons with some part here (clustered)\n",
@@ -1906,7 +1906,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9c5f30a",
+   "id": "283ef1df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1929,7 +1929,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8d4980c",
+   "id": "7fe29b1d",
    "metadata": {},
    "source": [
     "## Owlery Images of neurons with some part here\n",
@@ -1939,7 +1939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "761632ac",
+   "id": "af16ec67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1962,7 +1962,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55fb1bc6",
+   "id": "193a805b",
    "metadata": {},
    "source": [
     "## Owlery individual parts\n",
@@ -1972,7 +1972,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "756bd294",
+   "id": "d23b6358",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1995,7 +1995,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "969ab96d",
+   "id": "4a34c596",
    "metadata": {},
    "source": [
     "## Images of neurons that develops from this\n",
@@ -2005,7 +2005,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1ce33cf",
+   "id": "71900150",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2028,7 +2028,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c2ef646",
+   "id": "8ef6721b",
    "metadata": {},
    "source": [
     "## Get anat_query\n",
@@ -2038,7 +2038,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec2d63da",
+   "id": "e6a73682",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2061,7 +2061,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d54ab6c1",
+   "id": "cb0c36b6",
    "metadata": {},
    "source": [
     "## Get user NBLAST results\n",
@@ -2071,7 +2071,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f150c870",
+   "id": "0251e82e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2094,7 +2094,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ebf816f",
+   "id": "5ef704c6",
    "metadata": {},
    "source": [
     "## Get downstream connectivity from SOLR\n",
@@ -2104,7 +2104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b3186f2",
+   "id": "d6805ec5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2127,7 +2127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "933455e9",
+   "id": "8df4fd4c",
    "metadata": {},
    "source": [
     "## Get upstream connectivity from SOLR\n",
@@ -2137,7 +2137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "049fe44c",
+   "id": "0faad024",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2160,7 +2160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6521cd1",
+   "id": "9f71a923",
    "metadata": {},
    "source": [
     "## Get term info\n",
@@ -2170,7 +2170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f6e9843",
+   "id": "c8380846",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2193,7 +2193,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30a52935",
+   "id": "777bee58",
    "metadata": {},
    "source": [
     "## Get cached VFB_JSON for Term\n",
@@ -2203,7 +2203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b36d9ef3",
+   "id": "685bc2cb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2226,7 +2226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98428fb9",
+   "id": "4cf25796",
    "metadata": {},
    "source": [
     "## Get anat_2_ep_query\n",
@@ -2236,7 +2236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9d45cd7",
+   "id": "a24dab36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2259,7 +2259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "038607f1",
+   "id": "a77e5336",
    "metadata": {},
    "source": [
     "## Get template_2_datasets_query\n",
@@ -2269,7 +2269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b49074a",
+   "id": "c9d56912",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2292,7 +2292,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "680fd897",
+   "id": "59c6b118",
    "metadata": {},
    "source": [
     "## Get all_datasets_query\n",
@@ -2302,7 +2302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a967429",
+   "id": "deef6dc6",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/model/vfb.xmi
+++ b/model/vfb.xmi
@@ -940,6 +940,12 @@
         name="Owlery Class Pass solr id list only"
         description="Keep nothing slimply pass solr ids"
         queryProcessorId="owleryToSolrIdOnlyQueryProcessor"/>
+    <queries
+        xsi:type="gep_2:ProcessQuery"
+        id="owlPassSolrIdListWithSelf"
+        name="Owlery Class Pass solr id list incl self"
+        description="Pass OWLERY subclass ids to SOLR with the focus term prepended so leaf classes still hit their own per-class Solr doc."
+        queryProcessorId="owleryToSolrIdWithSelfQueryProcessor"/>
   </dataSources>
   <dataSources
       id="owleryDataSourceRealise"
@@ -1349,7 +1355,7 @@
       id="ref_downstream_class_connectivity_query"
       name="Show downstream connectivity classes for Neuron Class"
       description="Show downstream connectivity by class for $NAME"
-      queryChain="//@dataSources.1/@queries.8 //@dataSources.1/@queries.18 //@dataSources.3/@queries.7">
+      queryChain="//@dataSources.1/@queries.8 //@dataSources.1/@queries.19 //@dataSources.3/@queries.7">
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.2"/>
   </queries>
@@ -1357,7 +1363,7 @@
       id="ref_upstream_class_connectivity_query"
       name="Show upstream connectivity classes for Neuron Class"
       description="Show upstream connectivity by class for $NAME"
-      queryChain="//@dataSources.1/@queries.8 //@dataSources.1/@queries.18 //@dataSources.3/@queries.8">
+      queryChain="//@dataSources.1/@queries.8 //@dataSources.1/@queries.19 //@dataSources.3/@queries.8">
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.2"/>
   </queries>


### PR DESCRIPTION
Switch `ref_downstream_class_connectivity_query` and `ref_upstream_class_connectivity_query` from `dataSources.1/queries.18` (`owlPassSolrIdListOnly`) to a new `dataSources.1/queries.19` (`owlPassSolrIdListWithSelf`). The new step is appended at the end of `owleryDataSourceSubclass` so no existing index renumbers — only the two connectivity refs change.

Companion change: `VirtualFlyBrain/uk.ac.vfb.geppetto` PR introducing `OWLtoSOLRidWithSelfQueryProcessor` (bean id `owleryToSolrIdWithSelfQueryProcessor`). Both must ship together.

Test plan: rebuild geppetto-vfb v2-dev with the new uk.ac.vfb.geppetto bundle, smoke MBON11 (`FBbt_00100246`, leaf — currently returns 0, expect rows) and Kenyon cell (`FBbt_00003686`, 37 subclasses — should keep returning rows).

`README.md` / `query.md` not regenerated here — will run `model/queries_execution_notebook.ipynb` after the new step is settled.

Out of scope (follow-up): the `epFrag` chain at `model/vfb.xmi:1204` references `dataSources.1/queries.18` after an instance-side first step. Wrong datasource for the processor's switch (it'll look for `superClassOf` on a `hasInstance` result). Pre-existing bug, separate fix on `development`.
