### PR TITLE
epFrag: route through instance-side processor not subclass-side

### DIFF
--- a/model/README.md
+++ b/model/README.md
@@ -34,7 +34,7 @@
 
 ## epFrag: Images of fragments of $NAME
 - Step: Owlery individual parts (DataSource Index: 2, Query Index: 2)
-- Step: Owlery Class Pass solr id list only (DataSource Index: 1, Query Index: 18)
+- Step: Owlery Ind Pass solr id list only (DataSource Index: 2, Query Index: 4)
 - Step: Get and process example images from SOLR from id list (DataSource Index: 3, Query Index: 1)
 
 ## NeuronsSynaptic: Neurons with synaptic terminals in $NAME

--- a/model/queries_execution_notebook.ipynb
+++ b/model/queries_execution_notebook.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b4f6289f",
+   "id": "7213dd3c",
    "metadata": {},
    "source": [
     "# Query Execution Notebook"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d1c6f88",
+   "id": "d98763e8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0cb7f61",
+   "id": "82b47684",
    "metadata": {},
    "source": [
     "## anatomy_query\n",
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2789434",
+   "id": "eead2074",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf530f04",
+   "id": "de36620c",
    "metadata": {},
    "source": [
     "## anat_image_query\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28865acb",
+   "id": "93f51a8d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aabd1c79",
+   "id": "0731941c",
    "metadata": {},
    "source": [
     "## Get other cluster members\n",
@@ -104,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25b197ff",
+   "id": "db7151f7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17ee238c",
+   "id": "0b0cfc62",
    "metadata": {},
    "source": [
     "## Fetch all example individuals for Class\n",
@@ -141,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f77b0ad7",
+   "id": "a483afbb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4dacfc5",
+   "id": "6f2593ac",
    "metadata": {},
    "source": [
     "## Find domain individuals for template id\n",
@@ -178,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b7cfdab5",
+   "id": "aafc683c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70f5846d",
+   "id": "7290df42",
    "metadata": {},
    "source": [
     "## Get cluster members\n",
@@ -215,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "316518ed",
+   "id": "c73b5ec9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "038c5848",
+   "id": "f4a15308",
    "metadata": {},
    "source": [
     "## Find images for dataset\n",
@@ -252,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17b4fad7",
+   "id": "7f6f706d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b903eed",
+   "id": "7c05e910",
    "metadata": {},
    "source": [
     "## Test Query for Exp from Anatomy\n",
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ee8c493",
+   "id": "54c9833f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb9f0628",
+   "id": "99976353",
    "metadata": {},
    "source": [
     "## Query for Anatomy from Exp\n",
@@ -326,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "149c847b",
+   "id": "fa521e07",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d14db466",
+   "id": "aa9e6b2c",
    "metadata": {},
    "source": [
     "## Test Query for Anatomy from Exp\n",
@@ -363,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd8b3893",
+   "id": "5144fa31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c78f651e",
+   "id": "9a878a32",
    "metadata": {},
    "source": [
     "## Query for Exp from Anatomy\n",
@@ -400,7 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48e9c636",
+   "id": "a811c045",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +427,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d8aeba2",
+   "id": "3df95514",
    "metadata": {},
    "source": [
     "## test_all_datasets_query\n",
@@ -437,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03e3faff",
+   "id": "2733ec5e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +464,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bf5f19c",
+   "id": "c49f01a5",
    "metadata": {},
    "source": [
     "## Query for Exp from Anatomy\n",
@@ -474,7 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d58c7ef",
+   "id": "c840ea2a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +501,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0861825",
+   "id": "10f85fe3",
    "metadata": {},
    "source": [
     "## neuron_region_connectivity_query\n",
@@ -511,7 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6903faee",
+   "id": "11102241",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +538,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8a9429c",
+   "id": "e86206ae",
    "metadata": {},
    "source": [
     "## neuron_neuron_connectivity_query\n",
@@ -548,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8704ea5b",
+   "id": "0c317ba0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -575,7 +575,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8c457a6",
+   "id": "9312a005",
    "metadata": {},
    "source": [
     "## NBLAST_anat_image_query\n",
@@ -585,7 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41502434",
+   "id": "e495f200",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -612,7 +612,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cbb2e6a3",
+   "id": "91ca40bd",
    "metadata": {},
    "source": [
     "## Fetch all entities for pub\n",
@@ -622,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "236e8f87",
+   "id": "bbd39ac9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -649,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b90d3e08",
+   "id": "ae64a2b9",
    "metadata": {},
    "source": [
     "## NBLAST_anat_image_query_exp\n",
@@ -659,7 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e7c8169",
+   "id": "57d1e599",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +686,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b898bba",
+   "id": "80d08711",
    "metadata": {},
    "source": [
     "## NB_anat_image_query\n",
@@ -696,7 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0c635a2",
+   "id": "b81566f6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -723,7 +723,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3e33b0f",
+   "id": "d62bb3b9",
    "metadata": {},
    "source": [
     "## Get JSON for cluster expression query\n",
@@ -733,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39ebbe8a",
+   "id": "cb6299e0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -760,7 +760,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1624696",
+   "id": "313efc4f",
    "metadata": {},
    "source": [
     "## Get JSON for anat scRNAseq query\n",
@@ -770,7 +770,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a701bec",
+   "id": "92e15e98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -797,7 +797,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31fa9c43",
+   "id": "cf1b849e",
    "metadata": {},
    "source": [
     "## Get JSON for dataset scRNAseq query\n",
@@ -807,7 +807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f7a7c86",
+   "id": "20eb3569",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -834,7 +834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5bfcdbd",
+   "id": "e9a80834",
    "metadata": {},
    "source": [
     "## Get JSON for cluster expression query\n",
@@ -844,7 +844,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4fcb44b4",
+   "id": "131d1bb4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -871,7 +871,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4051345",
+   "id": "3df4d8e4",
    "metadata": {},
    "source": [
     "## Get term core info\n",
@@ -881,7 +881,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df2fe164",
+   "id": "867b8d21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -908,7 +908,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cdf4308",
+   "id": "c314134d",
    "metadata": {},
    "source": [
     "## Get baseline term info\n",
@@ -918,7 +918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2422480",
+   "id": "c271832a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -945,7 +945,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40f5884b",
+   "id": "dabb63fa",
    "metadata": {},
    "source": [
     "## Get JSON for Class\n",
@@ -955,7 +955,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "423e12bf",
+   "id": "227419ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -982,7 +982,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52f1f6b8",
+   "id": "fa518e3b",
    "metadata": {},
    "source": [
     "## Get JSON for Neuron Class\n",
@@ -992,7 +992,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "811521a4",
+   "id": "58124d1e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1019,7 +1019,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "088fd13d",
+   "id": "6cd8aef6",
    "metadata": {},
    "source": [
     "## Get JSON for Split Class\n",
@@ -1029,7 +1029,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba2df267",
+   "id": "d89a54da",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,7 +1056,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77eb48c1",
+   "id": "ee0514ea",
    "metadata": {},
    "source": [
     "## Get JSON for Individual\n",
@@ -1066,7 +1066,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b34cbc8f",
+   "id": "151ac47e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1093,7 +1093,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1be0f5d6",
+   "id": "7530bab3",
    "metadata": {},
    "source": [
     "## Get JSON for Cluster\n",
@@ -1103,7 +1103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8c01eae",
+   "id": "855b047f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1130,7 +1130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc5303e9",
+   "id": "38d7b691",
    "metadata": {},
    "source": [
     "## Get JSON for Template\n",
@@ -1140,7 +1140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35121917",
+   "id": "2f12392a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1167,7 +1167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "972c77b9",
+   "id": "0d70534f",
    "metadata": {},
    "source": [
     "## Get JSON for pub\n",
@@ -1177,7 +1177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9234e87",
+   "id": "e5275007",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1204,7 +1204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7f9b132",
+   "id": "08e8dcbe",
    "metadata": {},
    "source": [
     "## Get JSON for DataSet\n",
@@ -1214,7 +1214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61e395fa",
+   "id": "bfb3a877",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1241,7 +1241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81f67f4d",
+   "id": "c2e9c161",
    "metadata": {},
    "source": [
     "## Get JSON for License\n",
@@ -1251,7 +1251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5b7d14d",
+   "id": "9f965619",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,7 +1278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75907433",
+   "id": "87aaa3bc",
    "metadata": {},
    "source": [
     "## Find images aligned to template id\n",
@@ -1288,7 +1288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "499ca5d6",
+   "id": "cf7d0baf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1315,7 +1315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6e563b8",
+   "id": "dc0a36f5",
    "metadata": {},
    "source": [
     "## template_2_datasets_ids\n",
@@ -1325,7 +1325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf7e39c0",
+   "id": "af376bb4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1352,7 +1352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e05fdebf",
+   "id": "d36dbc70",
    "metadata": {},
    "source": [
     "## all_datasets_ids\n",
@@ -1362,7 +1362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1cd995c8",
+   "id": "6d18e777",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1389,7 +1389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6a6196a",
+   "id": "a4191a00",
    "metadata": {},
    "source": [
     "## Find image ids for dataset\n",
@@ -1399,7 +1399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3aad32ca",
+   "id": "431efe0a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1426,7 +1426,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a08bef6",
+   "id": "a5362663",
    "metadata": {},
    "source": [
     "## Find images develops_from id\n",
@@ -1436,7 +1436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0bf1284f",
+   "id": "6787e10f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1463,7 +1463,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ef3dffc",
+   "id": "f2366518",
    "metadata": {},
    "source": [
     "## Find term ids ref in pub\n",
@@ -1473,7 +1473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb94f17a",
+   "id": "842045c5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1500,7 +1500,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e25ab44d",
+   "id": "dc2fd22e",
    "metadata": {},
    "source": [
     "## Owlery Part of\n",
@@ -1510,7 +1510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be3da235",
+   "id": "57413fe1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1533,7 +1533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51909a2e",
+   "id": "0e41573e",
    "metadata": {},
    "source": [
     "## Owlery Neuron class with part here\n",
@@ -1543,7 +1543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0841d40b",
+   "id": "bff2bd3d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1566,7 +1566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05777e5f",
+   "id": "71e13498",
    "metadata": {},
    "source": [
     "## Owlery Neurons Synaptic\n",
@@ -1576,7 +1576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39604f4c",
+   "id": "fad8f443",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1599,7 +1599,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82f2b847",
+   "id": "df120054",
    "metadata": {},
    "source": [
     "## Owlery Neurons Presynaptic\n",
@@ -1609,7 +1609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a05c9388",
+   "id": "2068f955",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1632,7 +1632,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be0c3057",
+   "id": "415231e8",
    "metadata": {},
    "source": [
     "## Owlery Neurons Postsynaptic\n",
@@ -1642,7 +1642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4638eb21",
+   "id": "e7464ed7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1665,7 +1665,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ee508e4",
+   "id": "c9419bef",
    "metadata": {},
    "source": [
     "## Owlery Neuron classes fasciculating here\n",
@@ -1675,7 +1675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "418853f4",
+   "id": "7428d775",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1698,7 +1698,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "addaed34",
+   "id": "5db779d9",
    "metadata": {},
    "source": [
     "## Owlery tracts in\n",
@@ -1708,7 +1708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d0ace07",
+   "id": "150c3b93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1731,7 +1731,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53f39a75",
+   "id": "7c6d6941",
    "metadata": {},
    "source": [
     "## Owlery Subclasses of\n",
@@ -1741,7 +1741,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69ea6df7",
+   "id": "1fdcbdfc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1764,7 +1764,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98953edf",
+   "id": "caa1f88a",
    "metadata": {},
    "source": [
     "## Owlery Lineage Clones\n",
@@ -1774,7 +1774,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f77e70c",
+   "id": "20f916a4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1797,7 +1797,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b486a8e5",
+   "id": "a601b2e8",
    "metadata": {},
    "source": [
     "## subClassOf cell that overlaps some X\n",
@@ -1807,7 +1807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e24c990e",
+   "id": "2602220b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1830,7 +1830,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e48e57d",
+   "id": "6dc2986b",
    "metadata": {},
    "source": [
     "## subClassOf overlaps some X\n",
@@ -1840,7 +1840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee9d387f",
+   "id": "45b617e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1863,7 +1863,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38574322",
+   "id": "8975128d",
    "metadata": {},
    "source": [
     "## subClassOf cell overlaps some X\n",
@@ -1873,7 +1873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eea1c309",
+   "id": "44bfa49c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1896,7 +1896,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de514493",
+   "id": "821fa2d3",
    "metadata": {},
    "source": [
     "## Owlery Images of neurons with some part here (clustered)\n",
@@ -1906,7 +1906,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dbdbb2de",
+   "id": "45b69366",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1929,7 +1929,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41595d37",
+   "id": "30f86ea0",
    "metadata": {},
    "source": [
     "## Owlery Images of neurons with some part here\n",
@@ -1939,7 +1939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ce1cba8",
+   "id": "ac0d9da2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1962,7 +1962,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad7fa6c8",
+   "id": "e274db41",
    "metadata": {},
    "source": [
     "## Owlery individual parts\n",
@@ -1972,7 +1972,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f73a8fa6",
+   "id": "5a0b0f08",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1995,7 +1995,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7dfd1968",
+   "id": "5e1f43ad",
    "metadata": {},
    "source": [
     "## Images of neurons that develops from this\n",
@@ -2005,7 +2005,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "676da9d8",
+   "id": "95fbe5a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2028,7 +2028,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8619b628",
+   "id": "9935c5ff",
    "metadata": {},
    "source": [
     "## Get anat_query\n",
@@ -2038,7 +2038,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0f57a14",
+   "id": "3761c9d5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2061,7 +2061,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "319636b8",
+   "id": "8f6962ca",
    "metadata": {},
    "source": [
     "## Get user NBLAST results\n",
@@ -2071,7 +2071,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "168a8ba8",
+   "id": "39fff24a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2094,7 +2094,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd1b61fd",
+   "id": "13b823fb",
    "metadata": {},
    "source": [
     "## Get downstream connectivity from SOLR\n",
@@ -2104,7 +2104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f199a85",
+   "id": "abd1bc53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2127,7 +2127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2660d3b2",
+   "id": "feaea0aa",
    "metadata": {},
    "source": [
     "## Get upstream connectivity from SOLR\n",
@@ -2137,7 +2137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b082291b",
+   "id": "bdd9dd61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2160,7 +2160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5939d267",
+   "id": "3e561093",
    "metadata": {},
    "source": [
     "## Get term info\n",
@@ -2170,7 +2170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0133865",
+   "id": "bfd5c872",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2193,7 +2193,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19e3f882",
+   "id": "db714587",
    "metadata": {},
    "source": [
     "## Get cached VFB_JSON for Term\n",
@@ -2203,7 +2203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fdeddbd",
+   "id": "e9e1ab09",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2226,7 +2226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcef0a6f",
+   "id": "784cbd87",
    "metadata": {},
    "source": [
     "## Get anat_2_ep_query\n",
@@ -2236,7 +2236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5014e54a",
+   "id": "577ca6a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2259,7 +2259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7228206",
+   "id": "c6e4aebc",
    "metadata": {},
    "source": [
     "## Get template_2_datasets_query\n",
@@ -2269,7 +2269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74e57f7a",
+   "id": "74531a68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2292,7 +2292,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56ef81f5",
+   "id": "1cbbdf01",
    "metadata": {},
    "source": [
     "## Get all_datasets_query\n",
@@ -2302,7 +2302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dee7b0e5",
+   "id": "7f84e64a",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/model/vfb.xmi
+++ b/model/vfb.xmi
@@ -1201,7 +1201,7 @@
       id="epFrag"
       name="Images of expression pattern fragments"
       description="Images of fragments of $NAME"
-      queryChain="//@dataSources.2/@queries.2 //@dataSources.1/@queries.18 //@dataSources.3/@queries.1">
+      queryChain="//@dataSources.2/@queries.2 //@dataSources.2/@queries.4 //@dataSources.3/@queries.1">
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.27"/>
   </queries>


### PR DESCRIPTION
## The bug

`epFrag` ("Images of fragments of \$NAME") at `model/vfb.xmi:~1204` references the wrong query-processor step. Its `queryChain` is `//@dataSources.2/@queries.2 //@dataSources.1/@queries.18 //@dataSources.3/@queries.1`. The processor at the second position is `OWLtoSOLRidQueryProcessor`, which `switch`es on `dataSource.getId()`. Because that step lives under `owleryDataSourceSubclass`, the switch looks for a `superClassOf` column. Input from step 1 comes from `owleryDataSourceRealise` and has only `hasInstance`, so `idIndex == -1`, the loop is skipped, the empty-handler emits `NO_RESULTS_PLACEHOLDER`, and Solr's `{!terms f=id}` filter matches nothing. `epFrag` returns zero rows for every term.

## The fix

Switch the middle reference to `dataSources.2/queries.4` (`Owlery Ind Pass solr id list only`). Same `OWLtoSOLRidQueryProcessor` bean, instantiated under `owleryDataSourceRealise` so it reads `hasInstance`. Same pattern as `ImagesNeurons` and `ImagesThatDevelopFrom`, both of which already work correctly. One-line XMI change, no new code or beans, no index renumbering.

## Test plan

After v2-dev rebuild, view an expression pattern with fragments (any `VFBexp_*` whose ontology page lists fragments as descendants) and confirm "Images of fragments of \$NAME" returns rows where it previously returned zero. Cross-check with v3-cached's `anat_image_query` field for the same term — preview rows there should now appear in the live UI.

## Context

Spotted during the audit for #1670. Same "silent zero" symptom from the `NO_RESULTS_PLACEHOLDER` fallback, but a static mis-wiring rather than the OWLERY-self-inclusion gap that #1670 fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)