### PR TITLE
Bump uk.ac.vfb.geppetto to v2.2.4.11 (OWLtoSOLRidWithSelfQueryProcessor)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG geppettoDatasourceRelease=VFBv2.3.4
 ARG geppettoModelSwcRelease=v1.0.1
 ARG geppettoFrontendRelease=VFBv2.1.0.7
 ARG geppettoClientRelease=VFBv2.3.1
-ARG ukAcVfbGeppettoRelease=v2.2.4.10
+ARG ukAcVfbGeppettoRelease=v2.2.4.11
 
 ARG mvnOpt="-Dhttps.protocols=TLSv1.2 -DskipTests --quiet -Pmaster"
 


### PR DESCRIPTION
## The bug

After [#1670](https://github.com/VirtualFlyBrain/geppetto-vfb/pull/1670) the class-connectivity chains in `model/vfb.xmi` reference a new query processor:

```
<queries id="owlPassSolrIdListWithSelf"
         name="Owlery Class Pass solr id list incl self"
         queryProcessorId="owleryToSolrIdWithSelfQueryProcessor"/>
```

The Java implementation, `OWLtoSOLRidWithSelfQueryProcessor.java`, was added by [VirtualFlyBrain/uk.ac.vfb.geppetto#104](https://github.com/VirtualFlyBrain/uk.ac.vfb.geppetto/pull/104) and lives on branch `v2.2.4.11`. The Dockerfile here was still pinned at `v2.2.4.10` — which has no such class. Spring couldn't resolve the bean in the deployed WAR, so the chain step at `dataSources.1/queries.19` returned empty, and class-connectivity queries silently returned 0 results on v2-dev even though Solr's `vfb_json` core has the data (e.g. 167 downstream / 53 upstream entries for `FBbt_00100246`).

## The fix

One-line `Dockerfile` change:

```diff
-ARG ukAcVfbGeppettoRelease=v2.2.4.10
+ARG ukAcVfbGeppettoRelease=v2.2.4.11
```

`v2.2.4.11` includes `src/main/java/uk/ac/vfb/geppetto/OWLtoSOLRidWithSelfQueryProcessor.java`; `v2.2.4.10` doesn't.

## Test plan

After v2-dev rebuild:

- Open https://v2-dev.virtualflybrain.org/org.geppetto.frontend/geppetto?id=FBbt_00100246 (MBON11, a leaf class) → "Show downstream connectivity by class for mushroom body output neuron 11" should now return rows (Solr has 167 downstream entries cached). Same for upstream (53).
- Sanity-check a class with subclasses too, to confirm the chain handles both leaf and non-leaf input.

## Context

Spotted while verifying #1670 went live. The XMI fix was correct but the WAR didn't ship the bean it referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)