### PR TITLE
Feature/vfbquery connectivity batch 2

### DIFF
--- a/model/README.md
+++ b/model/README.md
@@ -103,15 +103,13 @@
 - Step: Process solr query results (DataSource Index: 3, Query Index: 3)
 
 ## ref_neuron_region_connectivity_query: Show connectivity per region for $NAME
-- Step: neuron_region_connectivity_query (DataSource Index: 0, Query Index: 13)
+- Step: VFBquery NeuronRegionConnectivityQuery (DataSource Index: 4, Query Index: 3)
 
 ## ref_neuron_neuron_connectivity_query: Show neurons connected to $NAME
-- Step: neuron_neuron_connectivity_query (DataSource Index: 0, Query Index: 14)
+- Step: VFBquery NeuronNeuronConnectivityQuery (DataSource Index: 4, Query Index: 2)
 
 ## ref_downstream_class_connectivity_query: Show downstream connectivity by class for $NAME
-- Step: Owlery Subclasses of (DataSource Index: 1, Query Index: 8)
-- Step: Owlery Class Pass solr id list incl self (DataSource Index: 1, Query Index: 19)
-- Step: downstream_connectivity_query (DataSource Index: 3, Query Index: 7)
+- Step: VFBquery DownstreamClassConnectivity (DataSource Index: 4, Query Index: 1)
 
 ## ref_upstream_class_connectivity_query: Show upstream connectivity by class for $NAME
 - Step: VFBquery UpstreamClassConnectivity (DataSource Index: 4, Query Index: 0)

--- a/model/queries_execution_notebook.ipynb
+++ b/model/queries_execution_notebook.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "30a9371b",
+   "id": "ab78ab88",
    "metadata": {},
    "source": [
     "# Query Execution Notebook"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6e5ca7f",
+   "id": "11446baa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "664d6fc6",
+   "id": "cf117c05",
    "metadata": {},
    "source": [
     "## anatomy_query\n",
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5f2fee9",
+   "id": "290c24c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "389eec48",
+   "id": "a304038f",
    "metadata": {},
    "source": [
     "## anat_image_query\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b254b38c",
+   "id": "177b1048",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74f1010d",
+   "id": "eb514425",
    "metadata": {},
    "source": [
     "## Get other cluster members\n",
@@ -104,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8281bc5c",
+   "id": "3abddac4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52c9fa8a",
+   "id": "6f719b01",
    "metadata": {},
    "source": [
     "## Fetch all example individuals for Class\n",
@@ -141,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9aeac189",
+   "id": "73178c61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06332b3b",
+   "id": "95f6c512",
    "metadata": {},
    "source": [
     "## Find domain individuals for template id\n",
@@ -178,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c179b16",
+   "id": "1b34ca42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ce820f1",
+   "id": "910714cc",
    "metadata": {},
    "source": [
     "## Get cluster members\n",
@@ -215,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c266045",
+   "id": "e26b4319",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2386f7c0",
+   "id": "6dd6991a",
    "metadata": {},
    "source": [
     "## Find images for dataset\n",
@@ -252,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cc93738",
+   "id": "a76fe5bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30d48d96",
+   "id": "345a8c39",
    "metadata": {},
    "source": [
     "## Test Query for Exp from Anatomy\n",
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db289601",
+   "id": "632474e4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8c0bc7e",
+   "id": "4ce464fb",
    "metadata": {},
    "source": [
     "## Query for Anatomy from Exp\n",
@@ -326,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae89ed96",
+   "id": "324b877f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73629a47",
+   "id": "c4fca98d",
    "metadata": {},
    "source": [
     "## Test Query for Anatomy from Exp\n",
@@ -363,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a8973ae",
+   "id": "75cd3cde",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acef17b7",
+   "id": "a0b2aa02",
    "metadata": {},
    "source": [
     "## Query for Exp from Anatomy\n",
@@ -400,7 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c54a0b73",
+   "id": "39f3553e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +427,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36630c75",
+   "id": "b1637289",
    "metadata": {},
    "source": [
     "## test_all_datasets_query\n",
@@ -437,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46d4fc3a",
+   "id": "aa50fe3f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +464,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7689889",
+   "id": "5d86a5ee",
    "metadata": {},
    "source": [
     "## Query for Exp from Anatomy\n",
@@ -474,7 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64701bbd",
+   "id": "57ca32ba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +501,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc338f96",
+   "id": "50e1332a",
    "metadata": {},
    "source": [
     "## neuron_region_connectivity_query\n",
@@ -511,7 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b89e1b8",
+   "id": "561db4a1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +538,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a920e1ca",
+   "id": "d16dd55b",
    "metadata": {},
    "source": [
     "## neuron_neuron_connectivity_query\n",
@@ -548,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "558cc70f",
+   "id": "92b7a5b4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -575,7 +575,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5cd278d",
+   "id": "1b664c2e",
    "metadata": {},
    "source": [
     "## NBLAST_anat_image_query\n",
@@ -585,7 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf691cc3",
+   "id": "49809792",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -612,7 +612,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1dc39a47",
+   "id": "44e16f17",
    "metadata": {},
    "source": [
     "## Fetch all entities for pub\n",
@@ -622,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3840feb3",
+   "id": "306252f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -649,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39b2e04d",
+   "id": "7ebac0ca",
    "metadata": {},
    "source": [
     "## NBLAST_anat_image_query_exp\n",
@@ -659,7 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "824e8f91",
+   "id": "5ce186e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +686,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddf6826d",
+   "id": "1a920ebc",
    "metadata": {},
    "source": [
     "## NB_anat_image_query\n",
@@ -696,7 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b71d67a7",
+   "id": "697fb79a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -723,7 +723,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f9bedc5",
+   "id": "4f7c08ce",
    "metadata": {},
    "source": [
     "## Get JSON for cluster expression query\n",
@@ -733,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db0243a4",
+   "id": "256ba173",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -760,7 +760,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7aa0060",
+   "id": "6b33e95d",
    "metadata": {},
    "source": [
     "## Get JSON for anat scRNAseq query\n",
@@ -770,7 +770,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2494fece",
+   "id": "5828bf7e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -797,7 +797,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67d9d0be",
+   "id": "4cb42152",
    "metadata": {},
    "source": [
     "## Get JSON for dataset scRNAseq query\n",
@@ -807,7 +807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96e53084",
+   "id": "6afaba7e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -834,7 +834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "316e8c95",
+   "id": "b68e4676",
    "metadata": {},
    "source": [
     "## Get JSON for cluster expression query\n",
@@ -844,7 +844,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c55581cf",
+   "id": "db69f986",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -871,7 +871,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77f22104",
+   "id": "fa8192a3",
    "metadata": {},
    "source": [
     "## Get term core info\n",
@@ -881,7 +881,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26485d81",
+   "id": "162f5c44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -908,7 +908,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78e29ee0",
+   "id": "2693c254",
    "metadata": {},
    "source": [
     "## Get baseline term info\n",
@@ -918,7 +918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "618dfcbf",
+   "id": "42d5a689",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -945,7 +945,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d238db13",
+   "id": "0c3852eb",
    "metadata": {},
    "source": [
     "## Get JSON for Class\n",
@@ -955,7 +955,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8192a5c",
+   "id": "d198780b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -982,7 +982,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d9e48ee8",
+   "id": "1183d3dd",
    "metadata": {},
    "source": [
     "## Get JSON for Neuron Class\n",
@@ -992,7 +992,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ed7e3f6",
+   "id": "ac534196",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1019,7 +1019,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6cd7fad7",
+   "id": "fc35b240",
    "metadata": {},
    "source": [
     "## Get JSON for Split Class\n",
@@ -1029,7 +1029,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d593017b",
+   "id": "055a1170",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,7 +1056,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0851b6b1",
+   "id": "5dea8104",
    "metadata": {},
    "source": [
     "## Get JSON for Individual\n",
@@ -1066,7 +1066,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ee1c0c9",
+   "id": "de3143af",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1093,7 +1093,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d35816f",
+   "id": "eb46a683",
    "metadata": {},
    "source": [
     "## Get JSON for Cluster\n",
@@ -1103,7 +1103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25292c09",
+   "id": "c4fc2df4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1130,7 +1130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "769ea1d7",
+   "id": "0014568e",
    "metadata": {},
    "source": [
     "## Get JSON for Template\n",
@@ -1140,7 +1140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59ce3ef9",
+   "id": "97bc1927",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1167,7 +1167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "efcd19cc",
+   "id": "ef47d419",
    "metadata": {},
    "source": [
     "## Get JSON for pub\n",
@@ -1177,7 +1177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ef742f2",
+   "id": "e9539f84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1204,7 +1204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5f0108e",
+   "id": "bede5c82",
    "metadata": {},
    "source": [
     "## Get JSON for DataSet\n",
@@ -1214,7 +1214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "665e84e1",
+   "id": "2f2aa741",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1241,7 +1241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28ef631c",
+   "id": "dd9c4aa0",
    "metadata": {},
    "source": [
     "## Get JSON for License\n",
@@ -1251,7 +1251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5683d6d7",
+   "id": "14888125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,7 +1278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "762076bc",
+   "id": "f83fd5d4",
    "metadata": {},
    "source": [
     "## Find images aligned to template id\n",
@@ -1288,7 +1288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca4ba2a8",
+   "id": "c80b157c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1315,7 +1315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a75b92f8",
+   "id": "08551041",
    "metadata": {},
    "source": [
     "## template_2_datasets_ids\n",
@@ -1325,7 +1325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0621f911",
+   "id": "d04a0287",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1352,7 +1352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef7afb20",
+   "id": "b09b67cd",
    "metadata": {},
    "source": [
     "## all_datasets_ids\n",
@@ -1362,7 +1362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea60c2df",
+   "id": "6dc9701e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1389,7 +1389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "236de73b",
+   "id": "a667bbc6",
    "metadata": {},
    "source": [
     "## Find image ids for dataset\n",
@@ -1399,7 +1399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "afdf0c02",
+   "id": "99aa6b5e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1426,7 +1426,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8b22fa1",
+   "id": "ed0704e8",
    "metadata": {},
    "source": [
     "## Find images develops_from id\n",
@@ -1436,7 +1436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f42dfca5",
+   "id": "55a2f2be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1463,7 +1463,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18f44a8c",
+   "id": "4216d041",
    "metadata": {},
    "source": [
     "## Find term ids ref in pub\n",
@@ -1473,7 +1473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2d8f492",
+   "id": "78b5355e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1500,7 +1500,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8917fd92",
+   "id": "11e29b25",
    "metadata": {},
    "source": [
     "## Owlery Part of\n",
@@ -1510,7 +1510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3de4329d",
+   "id": "0f7295dd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1533,7 +1533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed325531",
+   "id": "c32f612a",
    "metadata": {},
    "source": [
     "## Owlery Neuron class with part here\n",
@@ -1543,7 +1543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aeb53437",
+   "id": "5d1a8f9d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1566,7 +1566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64ede29b",
+   "id": "c1a4e2a6",
    "metadata": {},
    "source": [
     "## Owlery Neurons Synaptic\n",
@@ -1576,7 +1576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "006496c4",
+   "id": "209d561d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1599,7 +1599,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02229032",
+   "id": "d36ace9e",
    "metadata": {},
    "source": [
     "## Owlery Neurons Presynaptic\n",
@@ -1609,7 +1609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "422a1408",
+   "id": "b67e9fc1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1632,7 +1632,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87d23533",
+   "id": "f72e40b6",
    "metadata": {},
    "source": [
     "## Owlery Neurons Postsynaptic\n",
@@ -1642,7 +1642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adccde34",
+   "id": "c7fc3ee1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1665,7 +1665,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e0e35d5",
+   "id": "2855fd0d",
    "metadata": {},
    "source": [
     "## Owlery Neuron classes fasciculating here\n",
@@ -1675,7 +1675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c040186",
+   "id": "ae29f528",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1698,7 +1698,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f13c8a6",
+   "id": "89363129",
    "metadata": {},
    "source": [
     "## Owlery tracts in\n",
@@ -1708,7 +1708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "914b9563",
+   "id": "ed96e1f4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1731,7 +1731,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa501d72",
+   "id": "74ad506e",
    "metadata": {},
    "source": [
     "## Owlery Subclasses of\n",
@@ -1741,7 +1741,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b928aa41",
+   "id": "8a2a00db",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1764,7 +1764,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58d18ae0",
+   "id": "8d016488",
    "metadata": {},
    "source": [
     "## Owlery Lineage Clones\n",
@@ -1774,7 +1774,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce777f3a",
+   "id": "07f46799",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1797,7 +1797,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c5945a1",
+   "id": "442b401d",
    "metadata": {},
    "source": [
     "## subClassOf cell that overlaps some X\n",
@@ -1807,7 +1807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "690a7834",
+   "id": "29703b7c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1830,7 +1830,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3ef395b",
+   "id": "da009b0d",
    "metadata": {},
    "source": [
     "## subClassOf overlaps some X\n",
@@ -1840,7 +1840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28ce5525",
+   "id": "3c3dff7c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1863,7 +1863,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da683299",
+   "id": "0afa313a",
    "metadata": {},
    "source": [
     "## subClassOf cell overlaps some X\n",
@@ -1873,7 +1873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7bb7b33b",
+   "id": "feac201f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1896,7 +1896,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4d08fcff",
+   "id": "c9fb2a1f",
    "metadata": {},
    "source": [
     "## Owlery Images of neurons with some part here (clustered)\n",
@@ -1906,7 +1906,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0700dea2",
+   "id": "dcd03b03",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1929,7 +1929,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c1592e5",
+   "id": "bfee8ce0",
    "metadata": {},
    "source": [
     "## Owlery Images of neurons with some part here\n",
@@ -1939,7 +1939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2c3580a",
+   "id": "4744342e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1962,7 +1962,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73ccfe40",
+   "id": "30c773e2",
    "metadata": {},
    "source": [
     "## Owlery individual parts\n",
@@ -1972,7 +1972,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd2d1a03",
+   "id": "9e807b7c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1995,7 +1995,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c785fd54",
+   "id": "ad448658",
    "metadata": {},
    "source": [
     "## Images of neurons that develops from this\n",
@@ -2005,7 +2005,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22fae413",
+   "id": "f627c332",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2028,7 +2028,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72413995",
+   "id": "1f27ac35",
    "metadata": {},
    "source": [
     "## Get anat_query\n",
@@ -2038,7 +2038,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6720f24d",
+   "id": "7a60e447",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2061,7 +2061,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5585cf3",
+   "id": "065f2399",
    "metadata": {},
    "source": [
     "## Get user NBLAST results\n",
@@ -2071,7 +2071,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5380988b",
+   "id": "77101fc3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2094,7 +2094,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f55c012",
+   "id": "26e578dc",
    "metadata": {},
    "source": [
     "## Get downstream connectivity from SOLR\n",
@@ -2104,7 +2104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43526b7d",
+   "id": "c11af28a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2127,7 +2127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6b6e91d",
+   "id": "cd2e0d74",
    "metadata": {},
    "source": [
     "## Get upstream connectivity from SOLR\n",
@@ -2137,7 +2137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3deb61c6",
+   "id": "75cefbec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2160,7 +2160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e866d4f",
+   "id": "d499023d",
    "metadata": {},
    "source": [
     "## Get term info\n",
@@ -2170,7 +2170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "733bd68e",
+   "id": "096cc593",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2193,7 +2193,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06b8a938",
+   "id": "fdc300ee",
    "metadata": {},
    "source": [
     "## Get cached VFB_JSON for Term\n",
@@ -2203,7 +2203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2cdff486",
+   "id": "529f0c07",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2226,7 +2226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "805394c7",
+   "id": "5224d8be",
    "metadata": {},
    "source": [
     "## Get anat_2_ep_query\n",
@@ -2236,7 +2236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed9c2a55",
+   "id": "dacbc716",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2259,7 +2259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa6057ef",
+   "id": "6a5f6051",
    "metadata": {},
    "source": [
     "## Get template_2_datasets_query\n",
@@ -2269,7 +2269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f532a4e",
+   "id": "a41f3d86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2292,7 +2292,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95aa4ef6",
+   "id": "0c7154ef",
    "metadata": {},
    "source": [
     "## Get all_datasets_query\n",
@@ -2302,7 +2302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "530eba9c",
+   "id": "c3912488",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2325,7 +2325,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f5e48ba",
+   "id": "57f17c91",
    "metadata": {},
    "source": [
     "## Fetch UpstreamClassConnectivity from v3-cached\n",
@@ -2335,16 +2335,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06e71bdf",
+   "id": "96e01c07",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Unknown data source type"
+    "\n",
+    "# Query execution for Solr or Owlery\n",
+    "import requests\n",
+    "import time\n",
+    "\n",
+    "id = 'YOUR_SINGLE_ID_HERE'  # Replace with an actual ID\n",
+    "ids = ['ID1', 'ID2']  # Replace with actual IDs\n",
+    "query_url = \"https://v3-cached.virtualflybrain.org/run_query?\" + \"?id={id}&amp;query_type=UpstreamClassConnectivity\".format(id=id, ids=','.join(ids))\n",
+    "\n",
+    "start_time = time.time()\n",
+    "response = requests.get(query_url)\n",
+    "end_time = time.time()\n",
+    "print('Status Code:', response.status_code)\n",
+    "print('Response:', response.text)\n",
+    "print('Time taken:', end_time - start_time)\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dec5ee17",
+   "id": "b2d65c58",
    "metadata": {},
    "source": [
     "## Fetch DownstreamClassConnectivity from v3-cached\n",
@@ -2354,16 +2368,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e752d3d4",
+   "id": "102c2fd3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Unknown data source type"
+    "\n",
+    "# Query execution for Solr or Owlery\n",
+    "import requests\n",
+    "import time\n",
+    "\n",
+    "id = 'YOUR_SINGLE_ID_HERE'  # Replace with an actual ID\n",
+    "ids = ['ID1', 'ID2']  # Replace with actual IDs\n",
+    "query_url = \"https://v3-cached.virtualflybrain.org/run_query?\" + \"?id={id}&amp;query_type=DownstreamClassConnectivity\".format(id=id, ids=','.join(ids))\n",
+    "\n",
+    "start_time = time.time()\n",
+    "response = requests.get(query_url)\n",
+    "end_time = time.time()\n",
+    "print('Status Code:', response.status_code)\n",
+    "print('Response:', response.text)\n",
+    "print('Time taken:', end_time - start_time)\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b8e08c65",
+   "id": "0ebce1f4",
    "metadata": {},
    "source": [
     "## Fetch NeuronNeuronConnectivityQuery from v3-cached\n",
@@ -2373,16 +2401,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65ae4b8a",
+   "id": "dc0a0888",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Unknown data source type"
+    "\n",
+    "# Query execution for Solr or Owlery\n",
+    "import requests\n",
+    "import time\n",
+    "\n",
+    "id = 'YOUR_SINGLE_ID_HERE'  # Replace with an actual ID\n",
+    "ids = ['ID1', 'ID2']  # Replace with actual IDs\n",
+    "query_url = \"https://v3-cached.virtualflybrain.org/run_query?\" + \"?id={id}&amp;query_type=NeuronNeuronConnectivityQuery\".format(id=id, ids=','.join(ids))\n",
+    "\n",
+    "start_time = time.time()\n",
+    "response = requests.get(query_url)\n",
+    "end_time = time.time()\n",
+    "print('Status Code:', response.status_code)\n",
+    "print('Response:', response.text)\n",
+    "print('Time taken:', end_time - start_time)\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "af3e6664",
+   "id": "ef04082f",
    "metadata": {},
    "source": [
     "## Fetch NeuronRegionConnectivityQuery from v3-cached\n",
@@ -2392,11 +2434,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e7f72e9",
+   "id": "451e930c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Unknown data source type"
+    "\n",
+    "# Query execution for Solr or Owlery\n",
+    "import requests\n",
+    "import time\n",
+    "\n",
+    "id = 'YOUR_SINGLE_ID_HERE'  # Replace with an actual ID\n",
+    "ids = ['ID1', 'ID2']  # Replace with actual IDs\n",
+    "query_url = \"https://v3-cached.virtualflybrain.org/run_query?\" + \"?id={id}&amp;query_type=NeuronRegionConnectivityQuery\".format(id=id, ids=','.join(ids))\n",
+    "\n",
+    "start_time = time.time()\n",
+    "response = requests.get(query_url)\n",
+    "end_time = time.time()\n",
+    "print('Status Code:', response.status_code)\n",
+    "print('Response:', response.text)\n",
+    "print('Time taken:', end_time - start_time)\n"
    ]
   }
  ],

--- a/model/queries_execution_notebook.ipynb
+++ b/model/queries_execution_notebook.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7be62d6e",
+   "id": "30a9371b",
    "metadata": {},
    "source": [
     "# Query Execution Notebook"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55990021",
+   "id": "e6e5ca7f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aad9f27c",
+   "id": "664d6fc6",
    "metadata": {},
    "source": [
     "## anatomy_query\n",
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01b396c8",
+   "id": "b5f2fee9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aad1cea1",
+   "id": "389eec48",
    "metadata": {},
    "source": [
     "## anat_image_query\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2624c41",
+   "id": "b254b38c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6cc8e7dd",
+   "id": "74f1010d",
    "metadata": {},
    "source": [
     "## Get other cluster members\n",
@@ -104,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d8fbcc4",
+   "id": "8281bc5c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85db5121",
+   "id": "52c9fa8a",
    "metadata": {},
    "source": [
     "## Fetch all example individuals for Class\n",
@@ -141,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1c36821",
+   "id": "9aeac189",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cdd39de",
+   "id": "06332b3b",
    "metadata": {},
    "source": [
     "## Find domain individuals for template id\n",
@@ -178,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43446330",
+   "id": "6c179b16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4abbb21",
+   "id": "3ce820f1",
    "metadata": {},
    "source": [
     "## Get cluster members\n",
@@ -215,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1deada61",
+   "id": "9c266045",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e98479b6",
+   "id": "2386f7c0",
    "metadata": {},
    "source": [
     "## Find images for dataset\n",
@@ -252,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44d01105",
+   "id": "6cc93738",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0d494e1",
+   "id": "30d48d96",
    "metadata": {},
    "source": [
     "## Test Query for Exp from Anatomy\n",
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6987837",
+   "id": "db289601",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9623c439",
+   "id": "a8c0bc7e",
    "metadata": {},
    "source": [
     "## Query for Anatomy from Exp\n",
@@ -326,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4819d4e",
+   "id": "ae89ed96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d634d904",
+   "id": "73629a47",
    "metadata": {},
    "source": [
     "## Test Query for Anatomy from Exp\n",
@@ -363,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "913eda4c",
+   "id": "6a8973ae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28304563",
+   "id": "acef17b7",
    "metadata": {},
    "source": [
     "## Query for Exp from Anatomy\n",
@@ -400,7 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "322a2a90",
+   "id": "c54a0b73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +427,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f8e9361",
+   "id": "36630c75",
    "metadata": {},
    "source": [
     "## test_all_datasets_query\n",
@@ -437,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d0e1c14",
+   "id": "46d4fc3a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +464,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fe1abe1",
+   "id": "c7689889",
    "metadata": {},
    "source": [
     "## Query for Exp from Anatomy\n",
@@ -474,7 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5fa16ca3",
+   "id": "64701bbd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +501,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67655602",
+   "id": "bc338f96",
    "metadata": {},
    "source": [
     "## neuron_region_connectivity_query\n",
@@ -511,7 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a6bc61a",
+   "id": "4b89e1b8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +538,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1d812b9",
+   "id": "a920e1ca",
    "metadata": {},
    "source": [
     "## neuron_neuron_connectivity_query\n",
@@ -548,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b3dfe9fd",
+   "id": "558cc70f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -575,7 +575,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "baca3fc0",
+   "id": "a5cd278d",
    "metadata": {},
    "source": [
     "## NBLAST_anat_image_query\n",
@@ -585,7 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43b4da2e",
+   "id": "cf691cc3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -612,7 +612,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0b5caad",
+   "id": "1dc39a47",
    "metadata": {},
    "source": [
     "## Fetch all entities for pub\n",
@@ -622,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51f0906f",
+   "id": "3840feb3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -649,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ceeb92b",
+   "id": "39b2e04d",
    "metadata": {},
    "source": [
     "## NBLAST_anat_image_query_exp\n",
@@ -659,7 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9febae9",
+   "id": "824e8f91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +686,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "075fe62b",
+   "id": "ddf6826d",
    "metadata": {},
    "source": [
     "## NB_anat_image_query\n",
@@ -696,7 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bdad3963",
+   "id": "b71d67a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -723,7 +723,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9805a71",
+   "id": "1f9bedc5",
    "metadata": {},
    "source": [
     "## Get JSON for cluster expression query\n",
@@ -733,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab6b0a75",
+   "id": "db0243a4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -760,7 +760,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "234d558c",
+   "id": "e7aa0060",
    "metadata": {},
    "source": [
     "## Get JSON for anat scRNAseq query\n",
@@ -770,7 +770,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bda3b4a9",
+   "id": "2494fece",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -797,7 +797,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee1b023b",
+   "id": "67d9d0be",
    "metadata": {},
    "source": [
     "## Get JSON for dataset scRNAseq query\n",
@@ -807,7 +807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a972d1ca",
+   "id": "96e53084",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -834,7 +834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32c6ad75",
+   "id": "316e8c95",
    "metadata": {},
    "source": [
     "## Get JSON for cluster expression query\n",
@@ -844,7 +844,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce62fbf6",
+   "id": "c55581cf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -871,7 +871,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5020f58",
+   "id": "77f22104",
    "metadata": {},
    "source": [
     "## Get term core info\n",
@@ -881,7 +881,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8ccdff6",
+   "id": "26485d81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -908,7 +908,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f17053ff",
+   "id": "78e29ee0",
    "metadata": {},
    "source": [
     "## Get baseline term info\n",
@@ -918,7 +918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88cbd2cf",
+   "id": "618dfcbf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -945,7 +945,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e834e97",
+   "id": "d238db13",
    "metadata": {},
    "source": [
     "## Get JSON for Class\n",
@@ -955,7 +955,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb2015f7",
+   "id": "a8192a5c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -982,7 +982,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8385fcd",
+   "id": "d9e48ee8",
    "metadata": {},
    "source": [
     "## Get JSON for Neuron Class\n",
@@ -992,7 +992,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d484903",
+   "id": "4ed7e3f6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1019,7 +1019,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d6bc051",
+   "id": "6cd7fad7",
    "metadata": {},
    "source": [
     "## Get JSON for Split Class\n",
@@ -1029,7 +1029,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "901b756c",
+   "id": "d593017b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,7 +1056,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41363c11",
+   "id": "0851b6b1",
    "metadata": {},
    "source": [
     "## Get JSON for Individual\n",
@@ -1066,7 +1066,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03746fc5",
+   "id": "8ee1c0c9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1093,7 +1093,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e488c742",
+   "id": "8d35816f",
    "metadata": {},
    "source": [
     "## Get JSON for Cluster\n",
@@ -1103,7 +1103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcae2a0d",
+   "id": "25292c09",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1130,7 +1130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2af94846",
+   "id": "769ea1d7",
    "metadata": {},
    "source": [
     "## Get JSON for Template\n",
@@ -1140,7 +1140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80788606",
+   "id": "59ce3ef9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1167,7 +1167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85f4c887",
+   "id": "efcd19cc",
    "metadata": {},
    "source": [
     "## Get JSON for pub\n",
@@ -1177,7 +1177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1c97900",
+   "id": "2ef742f2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1204,7 +1204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d184a6b2",
+   "id": "a5f0108e",
    "metadata": {},
    "source": [
     "## Get JSON for DataSet\n",
@@ -1214,7 +1214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15099050",
+   "id": "665e84e1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1241,7 +1241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11a1e2e5",
+   "id": "28ef631c",
    "metadata": {},
    "source": [
     "## Get JSON for License\n",
@@ -1251,7 +1251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dff9c806",
+   "id": "5683d6d7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,7 +1278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0700fd40",
+   "id": "762076bc",
    "metadata": {},
    "source": [
     "## Find images aligned to template id\n",
@@ -1288,7 +1288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d869e85a",
+   "id": "ca4ba2a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1315,7 +1315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ad26cb5",
+   "id": "a75b92f8",
    "metadata": {},
    "source": [
     "## template_2_datasets_ids\n",
@@ -1325,7 +1325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b4d102e",
+   "id": "0621f911",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1352,7 +1352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57330230",
+   "id": "ef7afb20",
    "metadata": {},
    "source": [
     "## all_datasets_ids\n",
@@ -1362,7 +1362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28786b96",
+   "id": "ea60c2df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1389,7 +1389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f78ee589",
+   "id": "236de73b",
    "metadata": {},
    "source": [
     "## Find image ids for dataset\n",
@@ -1399,7 +1399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1a4adc0",
+   "id": "afdf0c02",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1426,7 +1426,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fe8fd64",
+   "id": "e8b22fa1",
    "metadata": {},
    "source": [
     "## Find images develops_from id\n",
@@ -1436,7 +1436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f29bb3a8",
+   "id": "f42dfca5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1463,7 +1463,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfcc256c",
+   "id": "18f44a8c",
    "metadata": {},
    "source": [
     "## Find term ids ref in pub\n",
@@ -1473,7 +1473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd8b4833",
+   "id": "d2d8f492",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1500,7 +1500,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e944328b",
+   "id": "8917fd92",
    "metadata": {},
    "source": [
     "## Owlery Part of\n",
@@ -1510,7 +1510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13736364",
+   "id": "3de4329d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1533,7 +1533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6745486",
+   "id": "ed325531",
    "metadata": {},
    "source": [
     "## Owlery Neuron class with part here\n",
@@ -1543,7 +1543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d250ec67",
+   "id": "aeb53437",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1566,7 +1566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3943238",
+   "id": "64ede29b",
    "metadata": {},
    "source": [
     "## Owlery Neurons Synaptic\n",
@@ -1576,7 +1576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a2b6464",
+   "id": "006496c4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1599,7 +1599,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e0ee157",
+   "id": "02229032",
    "metadata": {},
    "source": [
     "## Owlery Neurons Presynaptic\n",
@@ -1609,7 +1609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b08108cb",
+   "id": "422a1408",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1632,7 +1632,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9eabb2b3",
+   "id": "87d23533",
    "metadata": {},
    "source": [
     "## Owlery Neurons Postsynaptic\n",
@@ -1642,7 +1642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e878efa6",
+   "id": "adccde34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1665,7 +1665,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1858b11",
+   "id": "0e0e35d5",
    "metadata": {},
    "source": [
     "## Owlery Neuron classes fasciculating here\n",
@@ -1675,7 +1675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45eebc18",
+   "id": "3c040186",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1698,7 +1698,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05651d2a",
+   "id": "8f13c8a6",
    "metadata": {},
    "source": [
     "## Owlery tracts in\n",
@@ -1708,7 +1708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb7d29ff",
+   "id": "914b9563",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1731,7 +1731,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5400e5d",
+   "id": "fa501d72",
    "metadata": {},
    "source": [
     "## Owlery Subclasses of\n",
@@ -1741,7 +1741,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c10d165",
+   "id": "b928aa41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1764,7 +1764,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f61cd31a",
+   "id": "58d18ae0",
    "metadata": {},
    "source": [
     "## Owlery Lineage Clones\n",
@@ -1774,7 +1774,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c35e265a",
+   "id": "ce777f3a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1797,7 +1797,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7628f01",
+   "id": "5c5945a1",
    "metadata": {},
    "source": [
     "## subClassOf cell that overlaps some X\n",
@@ -1807,7 +1807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29478f05",
+   "id": "690a7834",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1830,7 +1830,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1651b9d0",
+   "id": "d3ef395b",
    "metadata": {},
    "source": [
     "## subClassOf overlaps some X\n",
@@ -1840,7 +1840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f19742ea",
+   "id": "28ce5525",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1863,7 +1863,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1296fb5d",
+   "id": "da683299",
    "metadata": {},
    "source": [
     "## subClassOf cell overlaps some X\n",
@@ -1873,7 +1873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c4fb6a1",
+   "id": "7bb7b33b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1896,7 +1896,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52b98142",
+   "id": "4d08fcff",
    "metadata": {},
    "source": [
     "## Owlery Images of neurons with some part here (clustered)\n",
@@ -1906,7 +1906,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb555efd",
+   "id": "0700dea2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1929,7 +1929,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cab99fd5",
+   "id": "7c1592e5",
    "metadata": {},
    "source": [
     "## Owlery Images of neurons with some part here\n",
@@ -1939,7 +1939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd942253",
+   "id": "f2c3580a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1962,7 +1962,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2052713",
+   "id": "73ccfe40",
    "metadata": {},
    "source": [
     "## Owlery individual parts\n",
@@ -1972,7 +1972,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c6efe73",
+   "id": "cd2d1a03",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1995,7 +1995,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6d1eb71",
+   "id": "c785fd54",
    "metadata": {},
    "source": [
     "## Images of neurons that develops from this\n",
@@ -2005,7 +2005,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8e26d4b",
+   "id": "22fae413",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2028,7 +2028,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a5f02c0",
+   "id": "72413995",
    "metadata": {},
    "source": [
     "## Get anat_query\n",
@@ -2038,7 +2038,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5ba59d2",
+   "id": "6720f24d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2061,7 +2061,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff23396b",
+   "id": "f5585cf3",
    "metadata": {},
    "source": [
     "## Get user NBLAST results\n",
@@ -2071,7 +2071,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec6d560c",
+   "id": "5380988b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2094,7 +2094,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e309f8e1",
+   "id": "0f55c012",
    "metadata": {},
    "source": [
     "## Get downstream connectivity from SOLR\n",
@@ -2104,7 +2104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea6fdf52",
+   "id": "43526b7d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2127,7 +2127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67a768f0",
+   "id": "f6b6e91d",
    "metadata": {},
    "source": [
     "## Get upstream connectivity from SOLR\n",
@@ -2137,7 +2137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49c8d9b4",
+   "id": "3deb61c6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2160,7 +2160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ccf3ac5a",
+   "id": "6e866d4f",
    "metadata": {},
    "source": [
     "## Get term info\n",
@@ -2170,7 +2170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e37720c3",
+   "id": "733bd68e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2193,7 +2193,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "199b158e",
+   "id": "06b8a938",
    "metadata": {},
    "source": [
     "## Get cached VFB_JSON for Term\n",
@@ -2203,7 +2203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82c1084e",
+   "id": "2cdff486",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2226,7 +2226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "629e3358",
+   "id": "805394c7",
    "metadata": {},
    "source": [
     "## Get anat_2_ep_query\n",
@@ -2236,7 +2236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b45829c",
+   "id": "ed9c2a55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2259,7 +2259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5dd44ff2",
+   "id": "aa6057ef",
    "metadata": {},
    "source": [
     "## Get template_2_datasets_query\n",
@@ -2269,7 +2269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb1ba468",
+   "id": "4f532a4e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2292,7 +2292,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "833c398d",
+   "id": "95aa4ef6",
    "metadata": {},
    "source": [
     "## Get all_datasets_query\n",
@@ -2302,7 +2302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3df7bb3c",
+   "id": "530eba9c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2325,7 +2325,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80c4a6c1",
+   "id": "2f5e48ba",
    "metadata": {},
    "source": [
     "## Fetch UpstreamClassConnectivity from v3-cached\n",
@@ -2335,7 +2335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcff1a76",
+   "id": "06e71bdf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2344,7 +2344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53eda252",
+   "id": "dec5ee17",
    "metadata": {},
    "source": [
     "## Fetch DownstreamClassConnectivity from v3-cached\n",
@@ -2354,7 +2354,45 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f5fe8f2",
+   "id": "e752d3d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Unknown data source type"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8e08c65",
+   "metadata": {},
+   "source": [
+    "## Fetch NeuronNeuronConnectivityQuery from v3-cached\n",
+    "Description: GET /run_query?id=$ID&query_type=NeuronNeuronConnectivityQuery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65ae4b8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Unknown data source type"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af3e6664",
+   "metadata": {},
+   "source": [
+    "## Fetch NeuronRegionConnectivityQuery from v3-cached\n",
+    "Description: GET /run_query?id=$ID&query_type=NeuronRegionConnectivityQuery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e7f72e9",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/model/query.md
+++ b/model/query.md
@@ -1538,7 +1538,7 @@ vfbqueryJsonProcessor
 
 **ID:** vfbquery_downstream_class_connectivity
 
-**Description:** Cached class-level downstream connectivity for $NAME via VFBquery (v3-cached). Defined but not yet wired into any CompoundRefQuery; do not use until upstream pilot is dev-verified.
+**Description:** Cached class-level downstream connectivity for $NAME via VFBquery (v3-cached).
 
 **Type:** gep_2:CompoundQuery
 
@@ -1561,6 +1561,78 @@ vfbqueryJsonProcessor
 **ID:** None
 
 **Description:** Convert {headers, rows, count} envelope into geppetto rows; synthesise Upstream_Class column for the 9-column v2 layout.
+
+**Type:** gep_2:ProcessQuery
+
+**Query:**
+
+```java
+vfbqueryJsonProcessor
+```
+
+## Query Name: VFBquery NeuronNeuronConnectivityQuery
+
+**ID:** vfbquery_neuron_neuron_connectivity
+
+**Description:** Cached individual-level neuron-to-neuron connectivity for $NAME via VFBquery (v3-cached). Replaces the single-step Cypher chain on dataSources.0/queries.14.
+
+**Type:** gep_2:CompoundQuery
+
+### Query Name: Fetch NeuronNeuronConnectivityQuery from v3-cached
+
+**ID:** None
+
+**Description:** GET /run_query?id=$ID&query_type=NeuronNeuronConnectivityQuery.
+
+**Type:** gep_2:SimpleQuery
+
+**Query:**
+
+```java
+?id=$ID&query_type=NeuronNeuronConnectivityQuery
+```
+
+### Query Name: Process VFBquery JSON to QueryResults
+
+**ID:** None
+
+**Description:** Object-to-String formatting per column type (list-to-pipe-joined, integer-Numbers as ints) via the processor's generic path.
+
+**Type:** gep_2:ProcessQuery
+
+**Query:**
+
+```java
+vfbqueryJsonProcessor
+```
+
+## Query Name: VFBquery NeuronRegionConnectivityQuery
+
+**ID:** vfbquery_neuron_region_connectivity
+
+**Description:** Cached neuron-to-region (per-region presynaptic/postsynaptic terminals) connectivity for $NAME via VFBquery (v3-cached). Replaces the single-step Cypher chain on dataSources.0/queries.13.
+
+**Type:** gep_2:CompoundQuery
+
+### Query Name: Fetch NeuronRegionConnectivityQuery from v3-cached
+
+**ID:** None
+
+**Description:** GET /run_query?id=$ID&query_type=NeuronRegionConnectivityQuery.
+
+**Type:** gep_2:SimpleQuery
+
+**Query:**
+
+```java
+?id=$ID&query_type=NeuronRegionConnectivityQuery
+```
+
+### Query Name: Process VFBquery JSON to QueryResults
+
+**ID:** None
+
+**Description:** Object-to-String formatting per column type via the processor's generic path.
 
 **Type:** gep_2:ProcessQuery
 

--- a/model/vfb.xmi
+++ b/model/vfb.xmi
@@ -1137,7 +1137,7 @@
   <dataSources
       name="vfbquery"
       url="https://v3-cached.virtualflybrain.org/run_query"
-      dataSourceService="org.geppetto.datasources.vfbquery.VFBqueryDataSourceService"
+      dataSourceService="vfbqueryDataSource"
       dependenciesLibrary="//@libraries.0">
     <queries
         xsi:type="gep_2:CompoundQuery"

--- a/model/vfb.xmi
+++ b/model/vfb.xmi
@@ -1160,7 +1160,7 @@
         xsi:type="gep_2:CompoundQuery"
         id="vfbquery_downstream_class_connectivity"
         name="VFBquery DownstreamClassConnectivity"
-        description="Cached class-level downstream connectivity for $NAME via VFBquery (v3-cached). Defined but not yet wired into any CompoundRefQuery; do not use until upstream pilot is dev-verified.">
+        description="Cached class-level downstream connectivity for $NAME via VFBquery (v3-cached).">
       <queryChain
           xsi:type="gep_2:SimpleQuery"
           name="Fetch DownstreamClassConnectivity from v3-cached"
@@ -1171,6 +1171,40 @@
           xsi:type="gep_2:ProcessQuery"
           name="Process VFBquery JSON to QueryResults"
           description="Convert {headers, rows, count} envelope into geppetto rows; synthesise Upstream_Class column for the 9-column v2 layout."
+          queryProcessorId="vfbqueryJsonProcessor"/>
+    </queries>
+    <queries
+        xsi:type="gep_2:CompoundQuery"
+        id="vfbquery_neuron_neuron_connectivity"
+        name="VFBquery NeuronNeuronConnectivityQuery"
+        description="Cached individual-level neuron-to-neuron connectivity for $NAME via VFBquery (v3-cached). Replaces the single-step Cypher chain on dataSources.0/queries.14.">
+      <queryChain
+          xsi:type="gep_2:SimpleQuery"
+          name="Fetch NeuronNeuronConnectivityQuery from v3-cached"
+          description="GET /run_query?id=$ID&amp;query_type=NeuronNeuronConnectivityQuery."
+          query="?id=$ID&amp;query_type=NeuronNeuronConnectivityQuery"
+          countQuery="?id=$ID&amp;query_type=NeuronNeuronConnectivityQuery"/>
+      <queryChain
+          xsi:type="gep_2:ProcessQuery"
+          name="Process VFBquery JSON to QueryResults"
+          description="Object-to-String formatting per column type (list-to-pipe-joined, integer-Numbers as ints) via the processor's generic path."
+          queryProcessorId="vfbqueryJsonProcessor"/>
+    </queries>
+    <queries
+        xsi:type="gep_2:CompoundQuery"
+        id="vfbquery_neuron_region_connectivity"
+        name="VFBquery NeuronRegionConnectivityQuery"
+        description="Cached neuron-to-region (per-region presynaptic/postsynaptic terminals) connectivity for $NAME via VFBquery (v3-cached). Replaces the single-step Cypher chain on dataSources.0/queries.13.">
+      <queryChain
+          xsi:type="gep_2:SimpleQuery"
+          name="Fetch NeuronRegionConnectivityQuery from v3-cached"
+          description="GET /run_query?id=$ID&amp;query_type=NeuronRegionConnectivityQuery."
+          query="?id=$ID&amp;query_type=NeuronRegionConnectivityQuery"
+          countQuery="?id=$ID&amp;query_type=NeuronRegionConnectivityQuery"/>
+      <queryChain
+          xsi:type="gep_2:ProcessQuery"
+          name="Process VFBquery JSON to QueryResults"
+          description="Object-to-String formatting per column type via the processor's generic path."
           queryProcessorId="vfbqueryJsonProcessor"/>
     </queries>
   </dataSources>
@@ -1379,7 +1413,7 @@
       id="ref_neuron_region_connectivity_query"
       name="Show connectivity to regions from Neuron X"
       description="Show connectivity per region for $NAME"
-      queryChain="//@dataSources.0/@queries.13">
+      queryChain="//@dataSources.4/@queries.3">
     <matchingCriteria
         type="//@libraries.3/@types.43"/>
   </queries>
@@ -1387,7 +1421,7 @@
       id="ref_neuron_neuron_connectivity_query"
       name="Show connectivity to neurons from Neuron X"
       description="Show neurons connected to $NAME"
-      queryChain="//@dataSources.0/@queries.14">
+      queryChain="//@dataSources.4/@queries.2">
     <matchingCriteria
         type="//@libraries.3/@types.42"/>
   </queries>
@@ -1395,7 +1429,7 @@
       id="ref_downstream_class_connectivity_query"
       name="Show downstream connectivity classes for Neuron Class"
       description="Show downstream connectivity by class for $NAME"
-      queryChain="//@dataSources.1/@queries.8 //@dataSources.1/@queries.19 //@dataSources.3/@queries.7">
+      queryChain="//@dataSources.4/@queries.1">
     <matchingCriteria
         type="//@libraries.3/@types.1 //@libraries.3/@types.2"/>
   </queries>


### PR DESCRIPTION
Fixes for queries and test examples:

ref_upstream_class_connectivity_query on MBON11 (FBbt_00100246) → 53 rows
ref_downstream_class_connectivity_query on MBON11 → 167 rows
ref_neuron_neuron_connectivity_query on LPC1 (VFB_jrchk00s) → 80 rows
ref_neuron_region_connectivity_query on LPC1 → 1 row
