### PR TITLE
Query loading feedback: immediate reassuring notice across all entry …

### DIFF
--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -1398,6 +1398,11 @@ class VFBMain extends React.Component {
       that.addVfbId(that.idsFinalList);
 
       var callback = function () {
+        // Hide the in-progress notice now we have a response, so it
+        // never co-exists with the "0 results" terminal state. Matches
+        // the hide pattern in VFBTermInfo + VFBFocusTerm so all three
+        // query entry points clean up the same element.
+        $("#query-error-message").hide().text("");
         if ( that.urlQueryLoader.length == 0 && that.refs.querybuilderRef.props.model.count > 0 ) {
           // runQuery if any results
           that.refs.querybuilderRef.runQuery();
@@ -1407,7 +1412,7 @@ class VFBMain extends React.Component {
           const query = that.urlQueryLoader[0];
           // Fetch variable and addQuery, if no more queries left then run query.
           query
-            ? window[query.id] === undefined 
+            ? window[query.id] === undefined
               ? window.fetchVariableThenRun(query.id, function () {
                 that.refs.querybuilderRef.addQueryItem({ term: "", id: query.id, queryObj: Model[query.selection] }, callback)
               })
@@ -1425,9 +1430,21 @@ class VFBMain extends React.Component {
       };
 
       // Initial queries specified on URL
-      if (that.urlQueryLoader !== undefined) {
-        if (window[that.urlQueryLoader[0]] == undefined) {
-          that.urlQueryLoader[0]?.id && window.fetchVariableThenRun(that.urlQueryLoader[0]?.id, function () {
+      if (that.urlQueryLoader !== undefined && that.urlQueryLoader.length > 0 && that.urlQueryLoader[0]?.id) {
+        // Surface loading feedback to the user *before* the round-trip
+        // starts. The click-driven query paths (VFBTermInfo / VFBFocusTerm)
+        // already do this; without it, ?q= deep links land on a page
+        // that looks idle until results pop in. Same spin / cursor /
+        // notice triplet, same hide in the callback.
+        GEPPETTO.trigger('spin_logo');
+        $("body").css("cursor", "progress");
+        $("#query-error-message")
+          .css({ color: "#9be7ff", fontWeight: "normal" })
+          .text("Fetching results — this can take a moment for complex queries.")
+          .show();
+
+        if (window[that.urlQueryLoader[0]?.id] === undefined) {
+          window.fetchVariableThenRun(that.urlQueryLoader[0].id, function () {
             that.refs.querybuilderRef.addQueryItem({ term: "", id: that.urlQueryLoader[0]?.id, queryObj: Model[that.urlQueryLoader[0]?.selection] }, callback)
           });
         } else {

--- a/components/interface/VFBFocusTerm/VFBFocusTerm.js
+++ b/components/interface/VFBFocusTerm/VFBFocusTerm.js
@@ -289,6 +289,9 @@ class VFBFocusTerm extends React.Component {
       var otherId = click.parameters[0].getId();
       var otherName = click.parameters[0].getName();
       var callback = function () {
+        // Hide the in-progress notice now we have a response, so it
+        // never co-exists with the "0 results" terminal state.
+        $("#query-error-message").hide().text("");
         // check if any results with count flag
         if (that.props.queryBuilder.props.model.count > 0) {
           // runQuery if any results
@@ -311,6 +314,14 @@ class VFBFocusTerm extends React.Component {
 
       GEPPETTO.trigger('spin_logo');
       $("body").css("cursor", "progress");
+      // Reassuring in-progress notice. See VFBTermInfo for the matching
+      // notice on the term-info click path and VFBMain for the ?q= deep
+      // link path -- same id + same hide pattern keeps all three paths
+      // consistent.
+      $("#query-error-message")
+        .css({ color: "#9be7ff", fontWeight: "normal" })
+        .text("Fetching results — this can take a moment for complex queries.")
+        .show();
       if (window[otherId] === undefined) {
         window.fetchVariableThenRun(otherId, function () {
           if ($('#add-new-query-container')[0] !== undefined) {

--- a/components/interface/VFBTermInfo/VFBTermInfo.js
+++ b/components/interface/VFBTermInfo/VFBTermInfo.js
@@ -853,12 +853,22 @@ class VFBTermInfoWidget extends React.Component {
           $('#query-builder-items-container')[0].hidden = true;
           $("#query-builder-footer").show();
           $("#run-query-btn").hide();
-          
-          setTimeout(function () {
-            $("#query-error-message").text("Still processing query (2 mins max). Click anywhere to run in background.").show();
-          }, 10000);
+
+          // Reassuring in-progress notice. Shown immediately so the user
+          // gets feedback during the round-trip (including ?q= deep-link
+          // open via VFBMain), not only after a 10s warning timer fires.
+          // Override the inline colour so the element stops rendering as
+          // an alarm-red error -- the id is preserved for back-compat
+          // with downstream CSS and tests.
+          $("#query-error-message")
+            .css({ color: "#9be7ff", fontWeight: "normal" })
+            .text("Fetching results — this can take a moment for complex queries.")
+            .show();
 
           var callback = function () {
+            // Hide the in-progress notice now we have a response, so it
+            // never co-exists with the "0 results" terminal state.
+            $("#query-error-message").hide().text("");
             // check if any results with count flag
             if (that.props.queryBuilder.props.model.count > 0) {
               // runQuery if any results


### PR DESCRIPTION
…points

Reviewer screenshot showed the v2-dev query widget rendering "0 results" (terminal state) and "Still processing query (2 mins max). Click anywhere to run in background." (loading state) at the same time. The two are meant to be mutually exclusive.

Root causes, both in the same query-result widget but visible only together when something else goes wrong:

1. VFBTermInfo.js sets the loading message on a 10s setTimeout and never clears it. If the query takes >10s and returns 0 rows, both layers paint. The 2-minute warning is also stale advice -- it was written for a pre-VFBquery era when slow queries were routine, and reads as alarming now.

2. The ?q= URL deep-link path in VFBMain.js has *no* user-visible feedback at all. It triggers no spin_logo, no cursor change, no loading message. A user opening a deep link sees a static page until results pop in, with nothing to indicate the query is even running in the background.

Fix:

- Replace the 10s setTimeout warning with an immediate, reassuring "Fetching results -- this can take a moment for complex queries." notice. Shown from t=0, hidden by the result callback.
- Override #query-error-message's inline colour at show-time so it stops rendering as an alarm-red error. We keep the id so any downstream CSS rules and Jest tests still find it.
- Mirror the show + hide pattern into VFBFocusTerm.js (click-from- 3D-viewer path -- already had spin_logo + cursor, just missing the notice).
- Add full feedback triplet (spin_logo + cursor:progress + notice) to VFBMain.js's urlQueryLoader deep-link path. Same hide in the callback as the click paths.

All three callbacks now hide the notice as their first action, so the split-state regression can't reoccur on any of the entry points.

Branch off development to feature/query-loading-feedback; open the PR by hand against development.

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
