### PR TITLE
Query loading feedback: use /* */ block comments to satisfy eslint mu…

### DIFF
--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -1398,10 +1398,12 @@ class VFBMain extends React.Component {
       that.addVfbId(that.idsFinalList);
 
       var callback = function () {
-        // Hide the in-progress notice now we have a response, so it
-        // never co-exists with the "0 results" terminal state. Matches
-        // the hide pattern in VFBTermInfo + VFBFocusTerm so all three
-        // query entry points clean up the same element.
+        /*
+         * Hide the in-progress notice now we have a response, so it
+         * never co-exists with the "0 results" terminal state. Matches
+         * the hide pattern in VFBTermInfo + VFBFocusTerm so all three
+         * query entry points clean up the same element.
+         */
         $("#query-error-message").hide().text("");
         if ( that.urlQueryLoader.length == 0 && that.refs.querybuilderRef.props.model.count > 0 ) {
           // runQuery if any results
@@ -1431,11 +1433,13 @@ class VFBMain extends React.Component {
 
       // Initial queries specified on URL
       if (that.urlQueryLoader !== undefined && that.urlQueryLoader.length > 0 && that.urlQueryLoader[0]?.id) {
-        // Surface loading feedback to the user *before* the round-trip
-        // starts. The click-driven query paths (VFBTermInfo / VFBFocusTerm)
-        // already do this; without it, ?q= deep links land on a page
-        // that looks idle until results pop in. Same spin / cursor /
-        // notice triplet, same hide in the callback.
+        /*
+         * Surface loading feedback to the user *before* the round-trip
+         * starts. The click-driven query paths (VFBTermInfo / VFBFocusTerm)
+         * already do this; without it, ?q= deep links land on a page
+         * that looks idle until results pop in. Same spin / cursor /
+         * notice triplet, same hide in the callback.
+         */
         GEPPETTO.trigger('spin_logo');
         $("body").css("cursor", "progress");
         $("#query-error-message")

--- a/components/interface/VFBFocusTerm/VFBFocusTerm.js
+++ b/components/interface/VFBFocusTerm/VFBFocusTerm.js
@@ -289,8 +289,10 @@ class VFBFocusTerm extends React.Component {
       var otherId = click.parameters[0].getId();
       var otherName = click.parameters[0].getName();
       var callback = function () {
-        // Hide the in-progress notice now we have a response, so it
-        // never co-exists with the "0 results" terminal state.
+        /*
+         * Hide the in-progress notice now we have a response, so it
+         * never co-exists with the "0 results" terminal state.
+         */
         $("#query-error-message").hide().text("");
         // check if any results with count flag
         if (that.props.queryBuilder.props.model.count > 0) {
@@ -314,10 +316,12 @@ class VFBFocusTerm extends React.Component {
 
       GEPPETTO.trigger('spin_logo');
       $("body").css("cursor", "progress");
-      // Reassuring in-progress notice. See VFBTermInfo for the matching
-      // notice on the term-info click path and VFBMain for the ?q= deep
-      // link path -- same id + same hide pattern keeps all three paths
-      // consistent.
+      /*
+       * Reassuring in-progress notice. See VFBTermInfo for the matching
+       * notice on the term-info click path and VFBMain for the ?q= deep
+       * link path -- same id + same hide pattern keeps all three paths
+       * consistent.
+       */
       $("#query-error-message")
         .css({ color: "#9be7ff", fontWeight: "normal" })
         .text("Fetching results — this can take a moment for complex queries.")

--- a/components/interface/VFBTermInfo/VFBTermInfo.js
+++ b/components/interface/VFBTermInfo/VFBTermInfo.js
@@ -854,20 +854,24 @@ class VFBTermInfoWidget extends React.Component {
           $("#query-builder-footer").show();
           $("#run-query-btn").hide();
 
-          // Reassuring in-progress notice. Shown immediately so the user
-          // gets feedback during the round-trip (including ?q= deep-link
-          // open via VFBMain), not only after a 10s warning timer fires.
-          // Override the inline colour so the element stops rendering as
-          // an alarm-red error -- the id is preserved for back-compat
-          // with downstream CSS and tests.
+          /*
+           * Reassuring in-progress notice. Shown immediately so the user
+           * gets feedback during the round-trip (including ?q= deep-link
+           * open via VFBMain), not only after a 10s warning timer fires.
+           * Override the inline colour so the element stops rendering as
+           * an alarm-red error -- the id is preserved for back-compat
+           * with downstream CSS and tests.
+           */
           $("#query-error-message")
             .css({ color: "#9be7ff", fontWeight: "normal" })
             .text("Fetching results — this can take a moment for complex queries.")
             .show();
 
           var callback = function () {
-            // Hide the in-progress notice now we have a response, so it
-            // never co-exists with the "0 results" terminal state.
+            /*
+             * Hide the in-progress notice now we have a response, so it
+             * never co-exists with the "0 results" terminal state.
+             */
             $("#query-error-message").hide().text("");
             // check if any results with count flag
             if (that.props.queryBuilder.props.model.count > 0) {


### PR DESCRIPTION
…ltiline-comment-style

CI Maven build (frontend-maven-plugin :: prebuild-dev :: eslint) rejected the consecutive `//` line comments in the original loading-feedback patch with:

  error  Expected a block comment instead of consecutive line
  comments  multiline-comment-style

Six sites across three files; convert each to a starred /* ... */ block comment matching the existing geppetto-vfb codebase convention. NO logic change.

Sites fixed:
  components/interface/VFBTermInfo/VFBTermInfo.js:857 and :869
  components/interface/VFBFocusTerm/VFBFocusTerm.js:292 and :317
  components/VFBMain.js:1401 and :1434

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
