### PR TITLE
Add MarkdownLinkComponent for per-cell term-link parsing

### DIFF
--- a/components/configuration/VFBMain/queryBuilderConfiguration.js
+++ b/components/configuration/VFBMain/queryBuilderConfiguration.js
@@ -4,6 +4,16 @@ var QueryLinkArrayComponent = require("@geppettoengine/geppetto-client/component
 var SlideshowImageComponent = require("@geppettoengine/geppetto-client/components/interface/query/customComponents/slideshowImageComponent");
 var QueryResultsControlsComponent = require("@geppettoengine/geppetto-client/components/interface/query/customComponents/queryResultsControlsComponent");
 var GrossTypeLabelsComponent = require('../../interface/utils/GrossTypeLabelsComponent');
+/*
+ * MarkdownLinkComponent parses `[label](short_form)` term-link markdown
+ * directly out of each cell value, supporting `; `-separated multi-chip
+ * cells. Replaces QueryLinkComponent + QueryLinkArrayComponent for
+ * every term-label-with-id column: the positional id-extraction via
+ * entityIndex / entityDelimiter is no longer needed, so click routing
+ * cannot misalign when a query's schema skips a canonical slot or
+ * reorders columns. Image / tag / slideshow columns are unchanged.
+ */
+var MarkdownLinkComponent = require('../../interface/utils/MarkdownLinkComponent');
 
 var queryResultsColMeta = [
   {
@@ -18,10 +28,8 @@ var queryResultsColMeta = [
     "order": 2,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 0,
-    "entityDelimiter": "----",
     "displayName": "Name",
     "cssClassName": "query-results-name-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -31,10 +39,8 @@ var queryResultsColMeta = [
     "order": 2,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 0,
-    "entityDelimiter": "----",
     "displayName": "Cluster",
     "cssClassName": "query-results-name-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -44,10 +50,8 @@ var queryResultsColMeta = [
     "order": 2,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 0,
-    "entityDelimiter": "----",
     "displayName": "Gene",
     "cssClassName": "query-results-name-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -57,10 +61,8 @@ var queryResultsColMeta = [
     "order": 2,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 0,
-    "entityDelimiter": "----",
     "displayName": "Neuron_A",
     "cssClassName": "query-results-name-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -70,10 +72,8 @@ var queryResultsColMeta = [
     "order": 3,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 1,
-    "entityDelimiter": "----",
     "displayName": "Type",
     "cssClassName": "query-results-type-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -83,10 +83,8 @@ var queryResultsColMeta = [
     "order": 3,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 1,
-    "entityDelimiter": "----",
     "displayName": "Cell type",
     "cssClassName": "query-results-type-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -96,10 +94,8 @@ var queryResultsColMeta = [
     "order": 3,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 1,
-    "entityDelimiter": "----",
     "displayName": "Parent",
     "cssClassName": "query-results-type-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -109,10 +105,8 @@ var queryResultsColMeta = [
     "order": 3,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 1,
-    "entityDelimiter": "----",
     "displayName": "Expressed_in",
     "cssClassName": "query-results-expressed_in-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -122,10 +116,8 @@ var queryResultsColMeta = [
     "order": 4,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 3,
-    "entityDelimiter": "----",
     "displayName": "Dataset",
     "cssClassName": "query-results-dataset-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -144,11 +136,8 @@ var queryResultsColMeta = [
     "order": 5,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkArrayComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 2,
-    "entityDelimiter": "----",
-    "stringDelimiter": ";",
     "displayName": "Reference",
     "cssClassName": "query-results-reference-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -231,10 +220,8 @@ var queryResultsColMeta = [
     "order": 1,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 2,
-    "entityDelimiter": "----",
     "displayName": "Partner_Neuron",
     "cssClassName": "query-results-name-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -244,10 +231,8 @@ var queryResultsColMeta = [
     "order": 2,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 1,
-    "entityDelimiter": "----",
     "displayName": "Region",
     "cssClassName": "query-results-name-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -257,10 +242,8 @@ var queryResultsColMeta = [
     "order": 11,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 1,
-    "entityDelimiter": "----",
     "displayName": "Target",
     "cssClassName": "query-results-name-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -270,10 +253,8 @@ var queryResultsColMeta = [
     "order": 8,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 1,
-    "entityDelimiter": "----",
     "displayName": "License",
     "cssClassName": "query-results-license-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -350,10 +331,8 @@ var queryResultsColMeta = [
     "order": 2,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 0,
-    "entityDelimiter": "----",
     "displayName": "Upstream_Class",
     "cssClassName": "query-results-name-column",
     "sortDirectionCycle": ['asc', 'desc', null]
@@ -363,10 +342,8 @@ var queryResultsColMeta = [
     "order": 3,
     "locked": false,
     "visible": true,
-    "customComponent": QueryLinkComponent,
+    "customComponent": MarkdownLinkComponent,
     "actions": "window.addVfbId('$entity$');",
-    "entityIndex": 1,
-    "entityDelimiter": "----",
     "displayName": "Downstream_Class",
     "cssClassName": "query-results-name-column",
     "sortDirectionCycle": ['asc', 'desc', null]

--- a/components/configuration/VFBMain/queryBuilderConfiguration.js
+++ b/components/configuration/VFBMain/queryBuilderConfiguration.js
@@ -1,6 +1,4 @@
 var Bloodhound = require("typeahead.js/dist/bloodhound.min.js");
-var QueryLinkComponent = require("@geppettoengine/geppetto-client/components/interface/query/customComponents/queryLinkComponent");
-var QueryLinkArrayComponent = require("@geppettoengine/geppetto-client/components/interface/query/customComponents/queryLinkArrayComponent");
 var SlideshowImageComponent = require("@geppettoengine/geppetto-client/components/interface/query/customComponents/slideshowImageComponent");
 var QueryResultsControlsComponent = require("@geppettoengine/geppetto-client/components/interface/query/customComponents/queryResultsControlsComponent");
 var GrossTypeLabelsComponent = require('../../interface/utils/GrossTypeLabelsComponent');

--- a/components/interface/utils/MarkdownLinkComponent.js
+++ b/components/interface/utils/MarkdownLinkComponent.js
@@ -1,0 +1,109 @@
+var React = require('react');
+
+/**
+ * MarkdownLinkComponent
+ *
+ * Renders a VFBquery result cell that contains one or more
+ * `[label](short_form)` term-link markdown items. Multi-item cells
+ * (e.g. the per-pub Reference column added in VFBquery v1.14.7, or the
+ * per-chip Type column added in NeuronNeuron / NeuronRegion connectivity
+ * queries) use `; ` between items; this component parses each one and
+ * emits an individual clickable chip, semicolon-separating them in the
+ * rendered output to match v2 prod styling.
+ *
+ * Replaces the legacy QueryLinkComponent + QueryLinkArrayComponent
+ * pattern that relied on positional id-extraction from the row's
+ * delimited id column (entityIndex / entityDelimiter / stringDelimiter
+ * config in queryBuilderConfiguration.js). The packed-id approach was
+ * brittle: column order, missing canonical slots, and per-query schema
+ * shape all had to line up exactly with the entityIndex value baked
+ * into queryBuilderConfiguration.js for the click to route to the right
+ * term. This component parses the id directly out of each cell's
+ * markdown, so it cannot misalign.
+ *
+ * REGEX SAFETY NOTES (per Robbie):
+ *
+ * Labels CAN contain `(`, `)`, `[`, `]` characters — e.g.
+ * "Wolff & Rubin, 2018, J. Comp. Neurol. 526(16): 2585--2611",
+ * "antennal lobe (left)", "FBbt_[deprecated]", and so on.
+ *
+ * The id portion in `[label](id)` is always a VFB / FlyBase
+ * short_form: `[A-Za-z0-9_-]+`. We exploit that constraint by
+ * restricting the id capture group to `[^()[\]]+` — anything BUT
+ * parens or brackets. The regex engine then backtracks the label
+ * capture (`(.*?)`) until the label/id boundary is consistent with
+ * the id constraint, even when the label itself contains parens or
+ * brackets.
+ *
+ * Examples that parse correctly:
+ *   [adult brain (left)](FBbt_123)        -> label="adult brain (left)", id="FBbt_123"
+ *   [antennal lobe [R]](FBbt_456)         -> label="antennal lobe [R]",  id="FBbt_456"
+ *   [Wolff & Rubin, 2018, J. Comp. Neurol. 526(16): 2585--2611](FBrf0240744)
+ *                                          -> label intact, id="FBrf0240744"
+ *   [a](id1); [b](id2); [c with [bracket]](id3)
+ *                                          -> three independent links
+ *   "plain text no link"                  -> rendered as plain text
+ *   ""                                    -> renders nothing
+ *
+ * Image markdown (`[![alt](url 'alt')](ref)`) is NOT handled here;
+ * that path is owned by the Java VFBqueryJsonProcessor's image-wrapping
+ * step and surfaced through SlideshowImageComponent for the Images
+ * column. This component is for term-label-with-id cells only.
+ *
+ * CAVEAT: if a real VFB short_form ever contains `(`, `)`, `[` or `]`,
+ * the id-character-class needs widening and the label/id boundary
+ * needs a different disambiguator. Current pdb data has no such ids.
+ */
+var TERM_LINK = /\[(.*?)\]\(([^()[\]]+)\)/g;
+
+function parseTermLinks(value)
+{
+    if (typeof value !== 'string' || !value) return [];
+    var out = [];
+    var m;
+    TERM_LINK.lastIndex = 0;
+    while ((m = TERM_LINK.exec(value)) !== null) {
+        out.push({ label: m[1], id: m[2] });
+    }
+    return out;
+}
+
+function MarkdownLinkComponent(props)
+{
+    var value = props && props.value;
+    var links = parseTermLinks(value);
+    if (links.length === 0) {
+        /* Not parseable as a term link — render the raw cell value as
+         * plain text so we don't silently drop content. Covers numeric,
+         * pipe-joined tag, empty cell, and any future schema additions. */
+        return value ? React.createElement('span', null, value) : null;
+    }
+    return React.createElement(
+        'span',
+        { className: 'markdown-link-cell' },
+        links.map(function (link, i) {
+            var sep = (i < links.length - 1) ? '; ' : null;
+            return React.createElement(
+                React.Fragment,
+                { key: i },
+                React.createElement(
+                    'a',
+                    {
+                        href: '#',
+                        'data-instancepath': link.id,
+                        onClick: function (e) {
+                            e.preventDefault();
+                            if (typeof window !== 'undefined' && typeof window.addVfbId === 'function') {
+                                window.addVfbId(link.id);
+                            }
+                        }
+                    },
+                    link.label
+                ),
+                sep
+            );
+        })
+    );
+}
+
+module.exports = MarkdownLinkComponent;


### PR DESCRIPTION
Robbie raised the question: how easily would it be to get griddle to take cell ids directly rather than the current packed-id-column approach? Turns out: very easily on the frontend side.

New component (components/interface/utils/MarkdownLinkComponent.js) parses `[label](short_form); [label](short_form); ...` markdown directly from each cell value and emits clickable chips. Replaces the positional id-extraction via QueryLinkComponent /
QueryLinkArrayComponent + entityIndex / entityDelimiter / stringDelimiter that has been the source of multiple chip-routing bugs over the migration.

Regex is robust against labels containing `(`, `)`, `[`, `]`:
  - `\[(.*?)\]\(([^()[\]]+)\)` constrains the id portion to chars that aren't parens or brackets (all VFB / FlyBase short_forms match `[A-Za-z0-9_-]+`).
  - The regex engine backtracks the label capture until the label/id boundary is consistent with the id constraint, so labels with embedded `(`, `)`, `[`, `]` are parsed correctly.

Verified against representative cells:
  [Wolff & Rubin, 2018, J. Comp. Neurol. 526(16): 2585--2611](FBrf0240744)
  [antennal lobe [R]](FBbt_456)
  [adult brain (left)](FBbt_123)
  [a](id1); [b](id2); [c with [bracket]](id3)
  plain text no link
  ""

16 queryBuilderConfiguration.js entries switched to MarkdownLinkComponent. entityIndex / entityDelimiter / stringDelimiter lines removed from each (no longer used). Image / tag / slideshow / control columns unchanged.

Supersedes:
  - VFBquery v1.15.0 (header order canonicalisation): no longer needed because slot positions don't drive click routing.
  - org.geppetto.datasources padding-for-missing-orders patch: ditto. Don't ship either; this PR makes them unnecessary.

Follow-up (not in this PR): the Java VFBqueryJsonProcessor's id-extraction + packed-id-column logic is now dead code for the 16 migrated columns but harmless. Clean up after verification.

Branch off development to feature/markdown-link-component; open PR by hand against development.

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
