### PR TITLE
VFBTree: scroll selected node into virtualised view

### DIFF
--- a/components/interface/VFBTree/VFBTree.js
+++ b/components/interface/VFBTree/VFBTree.js
@@ -94,6 +94,7 @@ class VFBTree extends React.Component {
     this.reloadData = this.reloadData.bind(this);
     this.monitorMouseClick = this.monitorMouseClick.bind(this);
     this.convertVfbqueryNode = this.convertVfbqueryNode.bind(this);
+    this.scrollSelectedIntoView = this.scrollSelectedIntoView.bind(this);
 
     this.theme = createMuiTheme({ overrides: { MuiTooltip: { tooltip: { fontSize: "12px" } } } });
     this.styles = {
@@ -123,6 +124,13 @@ class VFBTree extends React.Component {
      * already-resolved promise.
      */
     this._mounted = false;
+    /*
+     * Pending scroll-into-view timer (see scrollSelectedIntoView),
+     * held so componentWillUnmount can cancel it. treeContainer is the
+     * wrapping div ref used to scope the react-virtualized lookup.
+     */
+    this._scrollTimer = null;
+    this.treeContainer = null;
   }
 
   /*
@@ -603,6 +611,10 @@ class VFBTree extends React.Component {
 
   componentWillUnmount () {
     this._mounted = false;
+    if (this._scrollTimer) {
+      clearTimeout(this._scrollTimer);
+      this._scrollTimer = null;
+    }
     /*
      * Cancel any in-flight tree fetch so its .then doesn't try to
      * setState on this dead instance (React warning, leaked work).
@@ -645,6 +657,89 @@ class VFBTree extends React.Component {
     });
   }
 
+  /*
+   * react-virtualized (under react-sortable-tree) only mounts the rows
+   * near the current scroll offset, and the geppetto-ui Tree wrapper
+   * never forwards searchFocusOffset to react-sortable-tree. So a
+   * selected node is highlighted (.nodeFound) and its ancestors are
+   * expanded, but its row is never scrolled into the render window.
+   * When the TemplateROIBrowser response reorders siblings the selected
+   * node can fall below the initial window and its row stays unmounted -
+   * the batch3 'medulla' assertion then reads querySelector('.nodeFound')
+   * as null. Step the scroll offset down a viewport at a time until the
+   * row mounts, then centre it.
+   */
+  scrollSelectedIntoView () {
+    var self = this;
+    /*
+     * Defer: react-sortable-tree expands the new searchQuery's ancestor
+     * paths in a render cycle that runs after this componentDidUpdate,
+     * so the target row's offset isn't settled when we are first called.
+     */
+    if (this._scrollTimer) {
+      clearTimeout(this._scrollTimer);
+    }
+    this._scrollTimer = setTimeout(function () {
+      self._scrollTimer = null;
+      if (!self._mounted) {
+        return;
+      }
+      var container = self.treeContainer;
+      if (!container) {
+        return;
+      }
+      var grid = container.querySelector('.ReactVirtualized__Grid');
+      if (!grid) {
+        return;
+      }
+      var step = Math.max(self.styles.row_height, grid.clientHeight - self.styles.row_height);
+      var maxScroll = grid.scrollHeight;
+      var pos = 0;
+      var guard = 0;
+      var scan = function () {
+        if (!self._mounted) {
+          return;
+        }
+        var found = container.querySelector('.nodeFound');
+        if (found) {
+          found.scrollIntoView({ block: 'center', inline: 'nearest' });
+          return;
+        }
+        if (pos >= maxScroll || guard > 200) {
+          return;
+        }
+        guard++;
+        pos += step;
+        grid.scrollTop = pos;
+        /*
+         * Setting scrollTop programmatically does not always emit a
+         * scroll event synchronously; dispatch one so react-virtualized
+         * recomputes the rendered window before the next scan tick.
+         */
+        grid.dispatchEvent(new Event('scroll'));
+        setTimeout(scan, 50);
+      };
+      scan();
+    }, 150);
+  }
+
+  /*
+   * Scroll the selected row into the virtualised render window whenever
+   * the selection changes (focus-term load, node click, remount). The
+   * key compares subtitle + instanceId so colour-picker / forceUpdate
+   * re-renders that leave the selection untouched do not trigger a
+   * scroll.
+   */
+  componentDidUpdate (prevProps, prevState) {
+    var prevSel = prevState.nodeSelected;
+    var sel = this.state.nodeSelected;
+    var prevKey = prevSel ? (prevSel.subtitle + '|' + prevSel.instanceId) : '';
+    var selKey = sel ? (sel.subtitle + '|' + sel.instanceId) : '';
+    if (sel !== undefined && selKey !== prevKey && this.state.loading !== true) {
+      this.scrollSelectedIntoView();
+    }
+  }
+
   render () {
     if (this.state.dataTree === undefined) {
       var treeData = [{
@@ -665,7 +760,7 @@ class VFBTree extends React.Component {
     } else {
       // In the return we show the circular progress if the data are still being processed, differently the Tree
       return (
-        <div>
+        <div ref={el => { this.treeContainer = el; }}>
           {this.state.loading === true
             ? <CircularProgress
               style={{


### PR DESCRIPTION
batch3 tree-browser-tests.js asserts
document.querySelector(".nodeFound").innerText === "medulla" after the medulla focus term is loaded. The ROI tree renders through react-sortable-tree -> react-virtualized, which only mounts the rows near the current scroll offset. VFBTree selects the focus node (nodeSelected) and expands its ancestors via searchQuery, but the geppetto-ui Tree wrapper never forwards searchFocusOffset to react-sortable-tree, so the selected row is never scrolled into the render window.

While the medulla node sat near the top of the JFRC2 tree its row happened to fall inside react-virtualized's overscan at scrollTop 0, so the assertion passed. After the vfbquery TemplateROIBrowser response reordered siblings the node dropped below that window; its row stayed unmounted and querySelector returned null -> "Cannot read property 'innerText' of null". Confirmed on v2-dev: shrinking the tree panel so medulla falls outside the render window reproduces nodeFound === null, and stepping the scroll offset down until the row mounts restores it.

Add scrollSelectedIntoView(): on a selection change (componentDidUpdate, keyed on subtitle + instanceId so colour-picker / Color_set forceUpdate re-renders don't retrigger it) defer one tick for react-sortable-tree to commit the ancestor expansion, then step the react-virtualized grid's scrollTop down a viewport at a time until the .nodeFound row mounts and centre it. Scoped to a new treeContainer ref so the grid lookup can't match another component's virtualised list. Pending timer is cancelled in componentWillUnmount.

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
