### PR TITLE
VFBTree: braceless treeContainer ref to satisfy brace-style

### DIFF
--- a/components/interface/VFBTree/VFBTree.js
+++ b/components/interface/VFBTree/VFBTree.js
@@ -760,7 +760,7 @@ class VFBTree extends React.Component {
     } else {
       // In the return we show the circular progress if the data are still being processed, differently the Tree
       return (
-        <div ref={el => { this.treeContainer = el; }}>
+        <div ref={el => this.treeContainer = el}>
           {this.state.loading === true
             ? <CircularProgress
               style={{


### PR DESCRIPTION
The treeContainer ref added in PR #1688 used a braced arrow body, which fails the prebuild-dev eslint brace-style rule and breaks the build:

  VFBTree.js 763  error  Statement inside of curly braces should be on
                         next line  brace-style

Use the same braceless ref form already used elsewhere in this file (colorPickerContainer), which lints clean and behaves identically.

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
