### PR TITLE
CI: point development remote build at live servers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,12 +83,12 @@ jobs:
             echo "::set-output name=VFB_R_SERVER::http://r.virtualflybrain.org/ocpu/library/vfbr/R/vfb_nblast";
             echo "::set-output name=SOLR_SERVER::https://solr.virtualflybrain.org/solr/ontology/select";
           elif [ "${GITHUB_REF#refs/heads/}" == debug ] || [ "${GITHUB_REF#refs/heads/}" == pipeline2 ] || [ "${GITHUB_REF#refs/heads/}" == vfb_geppetto_application ] || [ "${GITHUB_REF#refs/heads/}" == development ] || [[ "${GITHUB_REF#refs/heads/}" == f* ]]; then
-            echo "::debug::Set to dev setup";
-            echo "::set-output name=VFB_PDB_SERVER::http://pdb-dev.virtualflybrain.org";
-            echo "::set-output name=VFB_OWL_SERVER::http://owl-dev.virtualflybrain.org/kbs/vfb/";
+            echo "::debug::Set to dev (live servers) setup";
+            echo "::set-output name=VFB_PDB_SERVER::http://pdb.v4.virtualflybrain.org";
+            echo "::set-output name=VFB_OWL_SERVER::http://owl.virtualflybrain.org/kbs/vfb/";
             echo "::set-output name=VFB_R_SERVER::http://r.virtualflybrain.org/ocpu/library/vfbr/R/vfb_nblast";
-            echo "::set-output name=VFB_TREE_PDB_SERVER::https://pdb-dev.virtualflybrain.org";
-            echo "::set-output name=SOLR_SERVER::https://solr-dev.virtualflybrain.org/solr/ontology/select";
+            echo "::set-output name=VFB_TREE_PDB_SERVER::https://pdb.v4.virtualflybrain.org";
+            echo "::set-output name=SOLR_SERVER::https://solr.virtualflybrain.org/solr/ontology/select";
           elif [ "${GITHUB_REF#refs/heads/}" == alpha ] ; then
             echo "::debug::Set to alpha setup";
             echo "::set-output name=VFB_PDB_SERVER::http://pdb-alpha.virtualflybrain.org";


### PR DESCRIPTION
The CI workflow builds two images per push, a -local.wss and a -remote, but the jest batches only ever run against the -remote image (the "Start VFB server" step launches ...-remote). For the development branch group the "Setup remote servers" step pointed that image at the *-dev.virtualflybrain.org PDB, OWL, tree-PDB and Solr servers, which carry staging/test data. Content and snapshot assertions intermittently broke whenever that test data changed, not because of a regression in the build.

Point the dev-group remote build (debug | pipeline2 | vfb_geppetto_application | development | f*) at the live servers already used by master/default: pdb.v4, owl, pdb.v4 (tree) and solr. R already targeted live. The local build, the alpha case and master/default are unchanged, so only the tested image moves to stable data.

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
