### PR TITLE
Managed loading: single VFBLoadManager owns scheduling, focus, status…

### DIFF
--- a/actions/generals.js
+++ b/actions/generals.js
@@ -12,6 +12,7 @@ export const INSTANCE_DELETED = 'INSTANCE_DELETED';
 export const INSTANCE_VISIBILITY_CHANGED = 'INSTANCE_VISIBILITY_CHANGED';
 export const SHOW_LIST_VIEWER = 'SHOW_LIST_VIEWER';
 export const INVALID_ID = 'INVALID_ID';
+export const LOAD_STATUS = 'LOAD_STATUS';
 
 export const vfbError = errorMessage => ({
   type: VFB_ERROR,
@@ -90,4 +91,13 @@ export const showListViewer = () => ({
 export const invalidIdLoaded = id => ({
   type: INVALID_ID,
   data : { id: id }
+});
+
+/*
+ * Status snapshot published by VFBLoadManager: the single source of truth for
+ * the progress overlay. { active, total, settled, failed:[], message }.
+ */
+export const setLoadStatus = snapshot => ({
+  type: LOAD_STATUS,
+  data : snapshot
 });

--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -117,6 +117,21 @@ class VFBMain extends React.Component {
 
     this.setSepCol = require('./interface/utils/utils').setSepCol;
     this.hasVisualType = require('./interface/utils/utils').hasVisualType;
+
+    /*
+     * Single owner of term loading. Everything that loads a term goes through
+     * this: it caps how many fetch at once, remembers the last id requested for
+     * display (focusId), dedups repeat requests, lets a slow term step aside so
+     * neighbours load, and publishes a live status for the progress overlay.
+     */
+    var VFBLoadManager = require('./interface/VFBLoader/VFBLoadManager').default;
+    this.loadManager = new VFBLoadManager({
+      concurrency: 3,
+      fetch: (id, callbacks) => this.managerFetch(id, callbacks),
+      onFocus: id => this.managerFocus(id),
+      onFailed: id => this.props.invalidIdLoaded(id),
+      publish: snapshot => this.props.setLoadStatus(snapshot)
+    });
     this.getStackViewerDefaultX = require('./interface/utils/utils').getStackViewerDefaultX;
     this.getStackViewerDefaultY = require('./interface/utils/utils').getStackViewerDefaultY;
 
@@ -183,24 +198,18 @@ class VFBMain extends React.Component {
       }
       window.ga('vfb.send', 'event', 'request', 'addvfbid', idsList.join(','));
       if (idsList != null && idsList.length > 0) {
-        for (var singleId = 0; idsList.length > singleId; singleId++) {
-          if ($.inArray(idsList[singleId], this.vfbLoadBuffer) == -1) {
-            this.vfbLoadBuffer.push(idsList[singleId]);
-          }
-          if (Instances.getInstance(idsList[singleId]) !== undefined) {
-            this.handleSceneAndTermInfoCallback(idsList[singleId]);
-            idsList.splice($.inArray(idsList[singleId], idsList), 1);
-            this.vfbLoadBuffer.splice($.inArray(idsList[singleId], this.vfbLoadBuffer), 1);
-          }
-        }
-        if (idsList.length > 0) {
-          this.props.vfbLoadId(idsList);
-          this.fetchVariableThenRun(idsList, this.handleSceneAndTermInfoCallback);
-          this.setState({
-            UIUpdated: false,
-            idSelected: idsList[idsList.length - 1]
-          });
-        }
+        /*
+         * Hand the whole request to the load manager. The last id is the display
+         * target (focus); the rest load silently. The manager caps concurrency,
+         * dedups repeats, and drives the overlay + focus -- replacing the old
+         * per-item fetch loop and its focus race.
+         */
+        this.loadManager.focusId = idsList[idsList.length - 1];
+        this.loadManager.requestMany(idsList, { displayLast: true });
+        this.setState({
+          UIUpdated: false,
+          idSelected: idsList[idsList.length - 1]
+        });
       }
 
     } else {
@@ -349,6 +358,57 @@ class VFBMain extends React.Component {
       GEPPETTO.trigger('spin_logo');
     } else {
       GEPPETTO.trigger('stop_spin_logo');
+    }
+  }
+
+  /*
+   * Per-item worker the load manager calls under its concurrency cap. Issues a
+   * single fetch_variable -- the manager owns the timeout/give-up, so there is
+   * NO retry here (retries only reloaded the serial sender and gridlocked
+   * loading) -- then runs the existing scene/term-info handling and reports the
+   * term resolved so the manager can free the slot and start the next one.
+   */
+  managerFetch (id, callbacks) {
+    var self = this;
+    var done = (callbacks && callbacks.onResolved) ? callbacks.onResolved : function () {};
+    var failed = (callbacks && callbacks.onFailed) ? callbacks.onFailed : function () {};
+    if (Instances.getInstance(id) !== undefined) {
+      this.handleSceneAndTermInfoCallback(id);
+      done();
+      return;
+    }
+    this.props.vfbLoadId([id]);
+    try {
+      Model.getDatasources()[5].fetchVariable(id, function () {
+        self.handleSceneAndTermInfoCallback(id);
+        done();
+      });
+    } catch (e) {
+      failed(e);
+    }
+  }
+
+  /*
+   * Apply focus for the manager's current display target: show it in Term Info
+   * and, if it has geometry, select it in the scene. Idempotent -- safe to call
+   * again when an already-loaded term is re-requested (re-click).
+   */
+  managerFocus (id) {
+    var meta;
+    try {
+      meta = Instances.getInstance(id + '.' + id + '_meta');
+    } catch (e) {
+      return;
+    }
+    if (meta !== undefined) {
+      this.handlerInstanceUpdate(meta);
+    }
+    var instance = Instances.getInstance(id);
+    if (this.hasVisualType(id) && instance !== undefined && typeof instance.select === "function") {
+      GEPPETTO.SceneController.deselectAll();
+      instance.select();
+    } else {
+      this.setActiveTab("termInfo");
     }
   }
 

--- a/components/interface/VFBLoader/VFBLoadManager.js
+++ b/components/interface/VFBLoader/VFBLoadManager.js
@@ -1,0 +1,324 @@
+/*
+ * VFBLoadManager -- single owner of term loading.
+ *
+ * The webapp used to drive loading from several places at once (addVfbId, the
+ * resolve3D callback, instance.select, and the idsMap/idsLoaded counter in the
+ * reducer). Those disagreed under out-of-order completion, slow/hung terms, and
+ * rapid clicks, which is what produced the "Loading N/M" freezes. This class is
+ * the single owner: everything that wants a term loaded calls request(); the
+ * manager decides what to fetch, how many at once, which one drives the display,
+ * and keeps a live status for the progress overlay.
+ *
+ * It is deliberately framework-agnostic -- geppetto/Redux specifics are injected
+ * as callbacks -- so it can be reasoned about (and unit-tested) on its own.
+ *
+ * Design points that map to explicit requirements:
+ *  - Robust to a single instance taking a very long time (up to ~20 min): a slow
+ *    term releases its concurrency slot after a short bootstrap window and keeps
+ *    loading in the background, so terms requested around it still load. The hard
+ *    give-up is 30 min, so a genuinely slow (not dead) instance is not killed.
+ *  - Idempotent per id: if a term is requested again while already in flight, no
+ *    second fetch is issued -- the repeat only re-points focus and waits on the
+ *    outstanding request.
+ *  - Out-of-order safe: focus/selection is applied only for the id that is the
+ *    current focus target at the moment it resolves, so a newer click supersedes
+ *    an older in-flight one instead of them fighting.
+ */
+
+export const LOAD_STATUS = {
+  QUEUED: 'queued',
+  FETCHING: 'fetching',
+  BACKGROUND: 'background',
+  LOADED: 'loaded',
+  FAILED: 'failed'
+};
+
+export default class VFBLoadManager {
+  constructor (opts = {}) {
+    // Max terms counting against the concurrency cap at once.
+    this.concurrency = opts.concurrency || 3;
+    /*
+     * After this long a still-unresolved term stops counting against the cap and
+     * continues loading in the background, freeing a slot for the next queued
+     * term. Normal terms resolve well inside this window; only genuinely slow
+     * ones get "backgrounded", which is what lets neighbours load around a slow
+     * instance.
+     */
+    this.backgroundAfterMs = opts.backgroundAfterMs || 45000;
+    // Hard give-up: only after this do we treat a term as failed and drain it.
+    this.itemTimeoutMs = opts.itemTimeoutMs || 1800000; // 30 min
+
+    // Injected side-effects (all optional; guarded at call sites).
+    this._fetch = opts.fetch; // (id, { onResolved, onFailed }) => void
+    this._onFocus = opts.onFocus; // (id) => void  -- apply term-info/selection
+    this._onFailed = opts.onFailed; // (id, error) => void -- drain loader entry
+    this._publish = opts.publish; // (snapshot) => void  -- push status to the UI
+
+    this.items = new Map(); // id -> { status, label, startedAt, bootstrapTimer, hardTimer, error }
+    this.queue = []; // ids awaiting a counting slot
+    this.loaded = new Set(); // ids already loaded this session (re-request => re-focus only)
+    this.focusId = undefined;
+
+    // Feedback counters for the current active batch.
+    this._total = 0;
+    this._settled = 0;
+  }
+
+  /* Public: request a term. display:true marks it the one to show. */
+  request (id, { display = true, label } = {}) {
+    if (!id) {
+      return;
+    }
+    if (display) {
+      this.focusId = id;
+    }
+
+    // Already loaded earlier: nothing to fetch, just move focus.
+    if (this.loaded.has(id) && !this.items.has(id)) {
+      if (display) {
+        this._applyFocus(id);
+      }
+      this._publishSnapshot();
+      return;
+    }
+
+    var existing = this.items.get(id);
+    if (existing && existing.status !== LOAD_STATUS.FAILED) {
+      /*
+       * Already queued/fetching/background: do NOT issue a second request. The
+       * outstanding one will resolve; a repeat with display only re-points focus.
+       */
+      this._publishSnapshot();
+      return;
+    }
+
+    this.items.set(id, {
+      status: LOAD_STATUS.QUEUED,
+      label: label || id,
+      startedAt: Date.now(),
+      bootstrapTimer: null,
+      hardTimer: null,
+      error: null
+    });
+    this.queue.push(id);
+    this._total++;
+    this._publishSnapshot();
+    this._pump();
+  }
+
+  /* Public: request several ids; the last is the display/focus target. */
+  requestMany (ids, { displayLast = true, labels } = {}) {
+    var list = Array.from(new Set((ids || []).filter(Boolean)));
+    for (var i = 0; i < list.length; i++) {
+      this.request(list[i], {
+        display: displayLast && i === list.length - 1,
+        label: labels && labels[list[i]]
+      });
+    }
+  }
+
+  /* Public: give a term a human label once known (drives the status line). */
+  setLabel (id, label) {
+    var it = this.items.get(id);
+    if (it && label) {
+      it.label = label;
+      this._publishSnapshot();
+    }
+  }
+
+  /* Number of terms currently counting against the concurrency cap. */
+  _countingSlots () {
+    var n = 0;
+    this.items.forEach(function (it) {
+      if (it.status === LOAD_STATUS.FETCHING) {
+        n++;
+      }
+    });
+    return n;
+  }
+
+  _pump () {
+    while (this._countingSlots() < this.concurrency && this.queue.length > 0) {
+      var id = this.queue.shift();
+      var it = this.items.get(id);
+      if (!it || it.status !== LOAD_STATUS.QUEUED) {
+        continue;
+      }
+      this._start(id);
+    }
+  }
+
+  _start (id) {
+    var self = this;
+    var it = this.items.get(id);
+    it.status = LOAD_STATUS.FETCHING;
+
+    /* Release the slot if this one turns out to be slow, so neighbours load. */
+    it.bootstrapTimer = setTimeout(function () {
+      var cur = self.items.get(id);
+      if (cur && cur.status === LOAD_STATUS.FETCHING) {
+        cur.status = LOAD_STATUS.BACKGROUND;
+        cur.bootstrapTimer = null;
+        self._publishSnapshot();
+        self._pump();
+      }
+    }, this.backgroundAfterMs);
+
+    /* Hard give-up so a dead (not merely slow) term cannot stick forever. */
+    it.hardTimer = setTimeout(function () {
+      self._fail(id, new Error('timed out after ' + Math.round(self.itemTimeoutMs / 60000) + ' min'));
+    }, this.itemTimeoutMs);
+
+    this._publishSnapshot();
+
+    try {
+      this._fetch(id, {
+        onResolved: function () {
+          self._resolved(id);
+        },
+        onFailed: function (err) {
+          self._fail(id, err || new Error('load failed'));
+        }
+      });
+    } catch (e) {
+      this._fail(id, e);
+    }
+  }
+
+  _resolved (id) {
+    var it = this.items.get(id);
+    if (!it || it.status === LOAD_STATUS.LOADED || it.status === LOAD_STATUS.FAILED) {
+      return;
+    }
+    this._clearTimers(it);
+    it.status = LOAD_STATUS.LOADED;
+    this.loaded.add(id);
+    this._settled++;
+    if (id === this.focusId) {
+      this._applyFocus(id);
+    }
+    this._publishSnapshot();
+    this._pump();
+  }
+
+  _fail (id, err) {
+    var it = this.items.get(id);
+    if (!it || it.status === LOAD_STATUS.LOADED || it.status === LOAD_STATUS.FAILED) {
+      return;
+    }
+    this._clearTimers(it);
+    it.status = LOAD_STATUS.FAILED;
+    it.error = (err && err.message) || String(err);
+    this._settled++;
+    try {
+      if (this._onFailed) {
+        this._onFailed(id, it.error);
+      }
+    } catch (e) {
+      // best-effort drain; ignore
+    }
+    this._publishSnapshot();
+    this._pump();
+  }
+
+  _applyFocus (id) {
+    try {
+      if (this._onFocus) {
+        this._onFocus(id);
+      }
+    } catch (e) {
+      // ignore focus errors
+    }
+  }
+
+  _clearTimers (it) {
+    if (it.bootstrapTimer) {
+      clearTimeout(it.bootstrapTimer);
+      it.bootstrapTimer = null;
+    }
+    if (it.hardTimer) {
+      clearTimeout(it.hardTimer);
+      it.hardTimer = null;
+    }
+  }
+
+  _active () {
+    if (this.queue.length > 0) {
+      return true;
+    }
+    var active = false;
+    this.items.forEach(function (it) {
+      if (it.status === LOAD_STATUS.FETCHING || it.status === LOAD_STATUS.BACKGROUND) {
+        active = true;
+      }
+    });
+    return active;
+  }
+
+  _currentLabel () {
+    if (this.focusId) {
+      var f = this.items.get(this.focusId);
+      if (f && (f.status === LOAD_STATUS.FETCHING || f.status === LOAD_STATUS.BACKGROUND)) {
+        return f.label;
+      }
+    }
+    var label = '';
+    this.items.forEach(function (it) {
+      if (!label && it.status === LOAD_STATUS.FETCHING) {
+        label = it.label;
+      }
+    });
+    if (!label) {
+      this.items.forEach(function (it) {
+        if (!label && it.status === LOAD_STATUS.BACKGROUND) {
+          label = it.label;
+        }
+      });
+    }
+    return label;
+  }
+
+  snapshot () {
+    var failed = [];
+    this.items.forEach(function (it, id) {
+      if (it.status === LOAD_STATUS.FAILED) {
+        failed.push(id);
+      }
+    });
+    if (!this._active()) {
+      return { active: false, total: this._total, settled: this._settled, failed: failed, message: '' };
+    }
+    var label = this._currentLabel();
+    return {
+      active: true,
+      total: this._total,
+      settled: this._settled,
+      failed: failed,
+      message: 'Loading ' + this._settled + '/' + this._total + (label ? ' — ' + label : '')
+    };
+  }
+
+  _publishSnapshot () {
+    var snap = this.snapshot();
+    if (!snap.active) {
+      // Batch finished: prune terminal entries and reset counters for the next one.
+      var self = this;
+      var toDelete = [];
+      this.items.forEach(function (it, id) {
+        if (it.status === LOAD_STATUS.LOADED || it.status === LOAD_STATUS.FAILED) {
+          self._clearTimers(it);
+          toDelete.push(id);
+        }
+      });
+      toDelete.forEach(function (id) {
+        self.items.delete(id);
+      });
+      this.queue = [];
+      this._total = 0;
+      this._settled = 0;
+    }
+    if (this._publish) {
+      this._publish(snap);
+    }
+  }
+}

--- a/components/interface/VFBLoader/VFBLoader.js
+++ b/components/interface/VFBLoader/VFBLoader.js
@@ -22,27 +22,30 @@ export default class VFBLoader extends Component {
   }
 
   render () {
-    if (!this.props.generals.loading) {
+    var status = this.props.generals.loadStatus || {};
+    if (!status.active) {
       return null;
     }
     return (
       <div>
-        <ProgressBar params={this.props.generals} />
+        <ProgressBar status={status} />
       </div>
     )
   }
 }
 
 const ProgressBar = props => {
-  let instancesToLoad = props.params.idsToLoad;
-  let instancesLoaded = props.params.idsLoaded + 1;
+  var status = props.status;
+  var pct = status.total > 0 ? Math.round((status.settled / status.total) * 100) : 0;
+  var failedCount = status.failed ? status.failed.length : 0;
+  var label = (status.message || "Loading ...") + (failedCount > 0 ? " (" + failedCount + " couldn't load)" : "");
   return (
-    <div className="progress-bar" datalabel={"Loading " + String(instancesLoaded) + "/" + String(instancesToLoad) + " ..."}>
-      <Filler stepsLoaded={props.params.stepsLoaded} stepsToLoad={props.params.stepsToLoad} />
+    <div className="progress-bar" datalabel={label}>
+      <Filler pct={pct} />
     </div>
   )
 };
 
 const Filler = props => (
-  <div className="filler" style={{ width: `${props.stepsLoaded * (100 / props.stepsToLoad)}%` }}></div>
+  <div className="filler" style={{ width: `${props.pct}%` }}></div>
 );

--- a/containers/VFBMainContainer.js
+++ b/containers/VFBMainContainer.js
@@ -10,7 +10,8 @@ import {
   setTermInfo,
   vfbGraph,
   vfbCircuitBrowser,
-  invalidIdLoaded
+  invalidIdLoaded,
+  setLoadStatus
 } from '../actions/generals';
 import { connect } from "react-redux";
 
@@ -27,7 +28,8 @@ const mapDispatchToProps = dispatch => ({
   instanceDeleted : (type, instanceID) => dispatch(instanceDeleted(type, instanceID)),
   instanceVisibilityChanged : instance => dispatch(instanceVisibilityChanged(instance)),
   setTermInfo: (instance, visible) => dispatch (setTermInfo(instance, visible)),
-  invalidIdLoaded: id => dispatch(invalidIdLoaded(id))
+  invalidIdLoaded: id => dispatch(invalidIdLoaded(id)),
+  setLoadStatus: snapshot => dispatch(setLoadStatus(snapshot))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(VFBMain);

--- a/reducers/generals.js
+++ b/reducers/generals.js
@@ -13,7 +13,8 @@ import {
   INSTANCE_SELECTED,
   INSTANCE_VISIBILITY_CHANGED,
   VFB_LOAD_TERM_INFO,
-  INVALID_ID
+  INVALID_ID,
+  LOAD_STATUS
 } from '../actions/generals';
 
 const componentsMap = require('../components/configuration/VFBLoader/VFBLoaderConfiguration').componentsMap;
@@ -28,6 +29,7 @@ export const GENERAL_DEFAULT_STATE = {
   stepsToLoad: 1,
   stepsLoaded: 0,
   loading: false,
+  loadStatus: { active: false, total: 0, settled: 0, failed: [], message: '' },
   instanceOnFocus : {},
   ui : {
     canvas : {
@@ -103,6 +105,17 @@ function generalReducer (state, action) {
     return {
       ...state,
       error: action.data
+    }
+  case LOAD_STATUS:
+    /*
+     * VFBLoadManager is the single owner of loading progress. Mirror its
+     * snapshot into loadStatus and keep the legacy `loading` boolean in sync so
+     * existing readers (spinner, guards) keep working off one source of truth.
+     */
+    return {
+      ...state,
+      loadStatus: action.data,
+      loading: action.data.active
     }
   case VFB_LOAD_ID:
     // check if data are provided as string or array of strings


### PR DESCRIPTION
… and per-item failure

Capped-parallel (3) with slot-release so a slow instance keeps loading in the background while neighbours load; per-id dedup (one fetch, then wait); focusId = last requested; overlay driven by a live status snapshot; per-item 30-min give-up drains instead of freezing the bar.

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
