### PR TITLE
Loader: treat window[id] as the already-loaded check so re-clicks re-…

### DIFF
--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -130,7 +130,8 @@ class VFBMain extends React.Component {
       fetch: (id, callbacks) => this.managerFetch(id, callbacks),
       onFocus: id => this.managerFocus(id),
       onFailed: id => this.props.invalidIdLoaded(id),
-      publish: snapshot => this.props.setLoadStatus(snapshot)
+      publish: snapshot => this.props.setLoadStatus(snapshot),
+      isLoaded: id => this.managerIsLoaded(id)
     });
     this.getStackViewerDefaultX = require('./interface/utils/utils').getStackViewerDefaultX;
     this.getStackViewerDefaultY = require('./interface/utils/utils').getStackViewerDefaultY;
@@ -405,6 +406,23 @@ class VFBMain extends React.Component {
     } catch (e) {
       failed(e);
     }
+  }
+
+  /*
+   * True when the term is already present in the model/scene, so a re-request
+   * (a click to view it) should just re-focus rather than load and count it
+   * again. Covers terms that came in with the initial scene (templates, painted
+   * domains) which the manager itself never requested.
+   */
+  managerIsLoaded (id) {
+    /*
+     * VFB sets window[<id>] when a term has been loaded (by any loader -- slice
+     * viewer click loads the class, shift+click loads the aligned-image
+     * Individual, plus URL/tree/graph paths). It is the path-independent source
+     * of truth, so if it exists the term is already loaded and a re-request
+     * should just re-focus rather than load and count it again.
+     */
+    return typeof window !== "undefined" && window[id] !== undefined;
   }
 
   /* Best-effort human label for the status line (falls back to the id). */

--- a/components/interface/VFBLoader/VFBLoadManager.js
+++ b/components/interface/VFBLoader/VFBLoadManager.js
@@ -61,6 +61,7 @@ export default class VFBLoadManager {
     this._onFocus = opts.onFocus; // (id) => void  -- apply term-info/selection
     this._onFailed = opts.onFailed; // (id, error) => void -- drain loader entry
     this._publish = opts.publish; // (snapshot) => void  -- push status to the UI
+    this._isLoaded = opts.isLoaded; // (id) => bool -- already present in the model/scene
 
     this.items = new Map(); // id -> { status, label, startedAt, bootstrapTimer, hardTimer, renderTimer, error }
     this.queue = []; // ids awaiting a counting slot
@@ -81,8 +82,15 @@ export default class VFBLoadManager {
       this.focusId = id;
     }
 
-    // Already loaded earlier: nothing to fetch, just move focus.
-    if (this.loaded.has(id) && !this.items.has(id)) {
+    /*
+     * Already available -- either this manager loaded it, or it is already in
+     * the model/scene (e.g. a template or painted domain that came in with the
+     * initial scene, which this manager never requested). Re-requesting such a
+     * term (a click to view it) must NOT enqueue or increment the loader; just
+     * move focus to it. Only applies when it is not currently mid-load.
+     */
+    if (!this.items.has(id) && (this.loaded.has(id) || (this._isLoaded && this._isLoaded(id)))) {
+      this.loaded.add(id);
       if (display) {
         this._applyFocus(id);
       }


### PR DESCRIPTION
…focus, not reload

A term is loaded (by any path -- slice-viewer click loads the class, shift+click loads the aligned-image Individual, plus URL/tree/graph) exactly when window[id] is set. VFBLoadManager now takes an injected isLoaded predicate and, for a term already loaded and not mid-load, just re-points focus instead of enqueuing and incrementing the loader. Verified live: window[id] is set only after a term is actually loaded.

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
