### PR TITLE
Load Term Info thumbnail clicks through the load manager

### DIFF
--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -116,6 +116,7 @@ class VFBMain extends React.Component {
 
     this.setSepCol = require('./interface/utils/utils').setSepCol;
     this.hasVisualType = require('./interface/utils/utils').hasVisualType;
+    this.hasUnresolvedVisualType = require('./interface/utils/utils').hasUnresolvedVisualType;
 
     /*
      * Single owner of term loading. Everything that loads a term goes through
@@ -431,7 +432,18 @@ class VFBMain extends React.Component {
      * of truth, so if it exists the term is already loaded and a re-request
      * should just re-focus rather than load and count it again.
      */
-    return typeof window !== "undefined" && window[id] !== undefined;
+    if ((typeof window === "undefined") || (window[id] === undefined)) {
+      return false;
+    }
+    /*
+     * window[id] only means the VARIABLE is in the model -- i.e. Term Info has
+     * been fetched. The term is not loaded until its visual types have been
+     * resolved into the scene; while any of them is still an ImportType there
+     * is geometry outstanding, and a re-request must load it rather than just
+     * re-focus. Treating "variable exists" as "loaded" is what made a Term Info
+     * thumbnail click show the term and never its image.
+     */
+    return !this.hasUnresolvedVisualType(id);
   }
 
   /* Best-effort human label for the status line (falls back to the id). */

--- a/components/interface/VFBLoader/VFBLoadManager.js
+++ b/components/interface/VFBLoader/VFBLoadManager.js
@@ -95,15 +95,33 @@ export default class VFBLoadManager {
      * through to the in-flight branch below and never re-displays (the "flick
      * between loaded terms a few times then it stops showing in Term Info" bug).
      */
-    if ((existing && existing.status === LOAD_STATUS.LOADED)
-        || this.loaded.has(id)
-        || (this._isLoaded && this._isLoaded(id))) {
+    var believedLoaded = (existing && existing.status === LOAD_STATUS.LOADED) || this.loaded.has(id);
+    /*
+     * _isLoaded inspects the model/scene, so it is authoritative when supplied.
+     * Our own bookkeeping can say LOADED for a term the render grace timed out
+     * on (settled without a paint) or one whose variable was fetched by another
+     * code path before it reached us; trusting that would make every later
+     * re-request a no-op re-focus, with the geometry never arriving at all.
+     */
+    var reallyLoaded = this._isLoaded ? this._isLoaded(id) : believedLoaded;
+    if (reallyLoaded) {
       this.loaded.add(id);
       if (display) {
         this._applyFocus(id);
       }
       this._publishSnapshot();
       return;
+    }
+    if (believedLoaded) {
+      /*
+       * We thought it was done but the scene disagrees -- drop the stale
+       * bookkeeping so the load below actually runs instead of being skipped.
+       */
+      this.loaded.delete(id);
+      if (existing && existing.status === LOAD_STATUS.LOADED) {
+        this.items.delete(id);
+        existing = undefined;
+      }
     }
 
     if (existing && existing.status !== LOAD_STATUS.FAILED) {

--- a/components/interface/VFBTermInfo/VFBTermInfo.js
+++ b/components/interface/VFBTermInfo/VFBTermInfo.js
@@ -852,7 +852,14 @@ class VFBTermInfoWidget extends React.Component {
       var target = widget;
       var that = this;
       var meta = path + "." + path + "_meta";
-      var n = window[meta];
+      /*
+       * Is this term already in the model? The meta variable hangs off the
+       * instance, at window[path][path + '_meta']. The flat window[path + '.' +
+       * path + '_meta'] key this used to read is never set by the model
+       * factory, so the branch below was unreachable and every thumbnail click
+       * fell through to the fetch path instead.
+       */
+      var n = (window[path] !== undefined) ? window[path][path + '_meta'] : undefined;
 
       if (n != undefined) {
         var metanode = Instances.getInstance(meta);
@@ -868,7 +875,13 @@ class VFBTermInfoWidget extends React.Component {
           }
         }
         this.setTermInfo(metanode, metanode.name);
-        window.resolve3D(path);
+        /*
+         * Hand off to the load manager rather than calling resolve3D directly,
+         * so a thumbnail click takes exactly the route a page-load id= takes.
+         * The manager resolves geometry that is not in the scene yet and just
+         * re-focuses when it already is.
+         */
+        window.addVfbId(path);
       } else {
         // check for passed ID:
         if (path.indexOf(',') > -1) {
@@ -993,11 +1006,14 @@ class VFBTermInfoWidget extends React.Component {
             that.props.queryBuilder.addQueryItem({ term: otherName, id: targetId, queryObj: entity, skipCount: true, previewCount: previewCount }, callback);
           });
         } else {
-          Model.getDatasources()[5].fetchVariable(path, function () {
-            var m = Instances.getInstance(meta);
-            this.setTermInfo(m, m.name);
-            window.addVfbId(path);
-          }.bind(this));
+          /*
+           * Not in the model yet: let the load manager own fetching, scene
+           * resolution and Term Info focus, exactly as it does for a page-load
+           * id=. Fetching here first set window[path], which made the manager
+           * treat the term as already loaded and skip its geometry entirely --
+           * the term appeared in Term Info and the viewers stayed empty.
+           */
+          window.addVfbId(path);
         }
       }
     } catch (e) {

--- a/components/interface/VFBTermInfo/VFBTermInfo.js
+++ b/components/interface/VFBTermInfo/VFBTermInfo.js
@@ -852,14 +852,7 @@ class VFBTermInfoWidget extends React.Component {
       var target = widget;
       var that = this;
       var meta = path + "." + path + "_meta";
-      /*
-       * Is this term already in the model? The meta variable hangs off the
-       * instance, at window[path][path + '_meta']. The flat window[path + '.' +
-       * path + '_meta'] key this used to read is never set by the model
-       * factory, so the branch below was unreachable and every thumbnail click
-       * fell through to the fetch path instead.
-       */
-      var n = (window[path] !== undefined) ? window[path][path + '_meta'] : undefined;
+      var n = window[meta];
 
       if (n != undefined) {
         var metanode = Instances.getInstance(meta);
@@ -875,13 +868,7 @@ class VFBTermInfoWidget extends React.Component {
           }
         }
         this.setTermInfo(metanode, metanode.name);
-        /*
-         * Hand off to the load manager rather than calling resolve3D directly,
-         * so a thumbnail click takes exactly the route a page-load id= takes.
-         * The manager resolves geometry that is not in the scene yet and just
-         * re-focuses when it already is.
-         */
-        window.addVfbId(path);
+        window.resolve3D(path);
       } else {
         // check for passed ID:
         if (path.indexOf(',') > -1) {
@@ -1006,14 +993,11 @@ class VFBTermInfoWidget extends React.Component {
             that.props.queryBuilder.addQueryItem({ term: otherName, id: targetId, queryObj: entity, skipCount: true, previewCount: previewCount }, callback);
           });
         } else {
-          /*
-           * Not in the model yet: let the load manager own fetching, scene
-           * resolution and Term Info focus, exactly as it does for a page-load
-           * id=. Fetching here first set window[path], which made the manager
-           * treat the term as already loaded and skip its geometry entirely --
-           * the term appeared in Term Info and the viewers stayed empty.
-           */
-          window.addVfbId(path);
+          Model.getDatasources()[5].fetchVariable(path, function () {
+            var m = Instances.getInstance(meta);
+            this.setTermInfo(m, m.name);
+            window.addVfbId(path);
+          }.bind(this));
         }
       }
     } catch (e) {

--- a/components/interface/utils/utils.js
+++ b/components/interface/utils/utils.js
@@ -422,7 +422,7 @@ var hasVisualType = function (variableId) {
   var extEnum = {
     0 : { extension: "_swc" },
     1 : { extension: "_obj" },
-    2 : { extension: "_slice" }
+    2 : { extension: "_slices" }
   };
   while ((instance == undefined) && (counter < 3)) {
     try {
@@ -437,10 +437,33 @@ var hasVisualType = function (variableId) {
   }
 };
 
+/*
+ * True when the term still has a visual child type that is an unresolved
+ * ImportType -- the mesh/stack has not been pulled into the scene yet.
+ * window[id] on its own only tells us the VARIABLE exists (Term Info has been
+ * fetched), which is a weaker condition and must not be mistaken for it.
+ */
+var hasUnresolvedVisualType = function (variableId) {
+  var ImportType = require('@geppettoengine/geppetto-core/model/ImportType');
+  var extensions = ["_swc", "_obj", "_slices"];
+  for (var i = 0; i < extensions.length; i++) {
+    try {
+      var child = Instances.getInstance(variableId + "." + variableId + extensions[i]);
+      if ((child !== undefined) && (child.getType() instanceof ImportType)) {
+        return true;
+      }
+    } catch (ignore) {
+      // No such child type on this term: nothing outstanding for this extension.
+    }
+  }
+  return false;
+};
+
 module.exports = {
   setSepCol,
   getStackViewerDefaultX,
   getStackViewerDefaultY,
   hasVisualType,
+  hasUnresolvedVisualType,
   labelTypeToID
 };


### PR DESCRIPTION
Clicking a thumbnail in Term Info showed the term and never its image: Term Info switched to the example individual, the Layers panel gained nothing, both viewers stayed empty, and the console was clean. Reported via vfb-support on 2026-08-06 for GAL4 expression patterns; it affects any term reached this way, including painted domains — `cantle` → the CAN example is the shortest reproduction.

## What is actually happening

Instrumented on v2-dev, clicking the CAN example on `cantle` (`FBbt_00045051` → `VFB_00102275`):

```
addVfbId:  [{ args: ["VFB_00102275"], alreadyInWindow: [true] }]
resolve3D: []
```

The handler *is* wired to the loader — `addVfbId` fires. But `customHandler` fetches the variable for Term Info first and only calls `addVfbId` from that callback, so `window[id]` is already set by then. `managerIsLoaded` was `window[id] !== undefined`, so `VFBLoadManager.request()` took the *already loaded → just re-focus* branch: `managerFetch`, `handleSceneAndTermInfoCallback` and `resolve3D` never ran, and `_obj` stayed an unresolved `ImportType`. Calling `window.resolve3D(id)` by hand painted the mesh immediately.

Generalised: **any caller that fetches a variable before handing the id to the load manager is silently skipped.** Nothing errors and the term counts as complete, which is why this looked intermittent rather than broken.

## The change

A term is loaded only once its geometry is in the scene:

- New `utils.hasUnresolvedVisualType(id)`: true while any `_swc`/`_obj`/`_slices` child type is still an `ImportType`.
- `managerIsLoaded` requires that to be false. `window[id]` alone only means the variable is in the model.
- `VFBLoadManager.request` treats an injected `isLoaded` as authoritative over its own bookkeeping, and drops stale bookkeeping when the two disagree. This also fixes the case where the 90 s render grace settles a term as LOADED without a paint — previously it stayed in `loaded` forever and every later click was a no-op re-focus.
- Fixes `hasVisualType` probing `"_slice"`; the child variable is `"_slices"`, so that arm never matched and an image with slices but no mesh was classified as having no visual type at all.

With that in place the existing handler reaches the geometry on its own: `addVfbId` is no longer dismissed, `request()` starts the item, and `managerFetch` takes its "already in the model" path into `handleSceneAndTermInfoCallback` — the same routine a page-load `id=` goes through, and the one that calls `resolve3D`. `VFBTermInfo.js` is untouched.

## Testing

- eslint clean.
- `VFBLoadManager` exercised directly (babel-transpiled to CJS, plain node): a pre-fetched term still loads; an already-in-scene term re-focuses without re-fetching; a re-click after a grace-without-paint really reloads; behaviour is unchanged when no `isLoaded` is injected. The third case **fails against the pre-fix manager**, so it is a genuine regression test rather than a tautology.
- Manual: open `?id=FBbt_00045051&i=VFB_00101567` and click the CAN thumbnail. Before: Term Info only. After: mesh in the 3D viewer, a Layers row, and `cantle` highlighted in the ROI Browser.

An earlier revision of this PR also rewrote `customHandler` to call `addVfbId` in place of its own fetch. That regressed batch 4 — the Source Link test polls for `id=JRC2018` in the SPA URL, which the dropped `setTermInfo` call was driving — and it turned out to be unnecessary, so it is reverted here (`c12bb96ce`). Note for a later PR: `customHandler`'s `window[path + "." + path + "_meta"]` is a flat lookup on a key containing a literal dot and is never set, so its first branch is dead and every term-info link click does a redundant `fetchVariable` for a term already in the model. Harmless, but worth tidying separately.

## Follow-up, not in this PR

Worth a separate issue against `org.geppetto.core`: `ObjModelInterpreterService.importType` sets no connect/read timeout on `url.openStream()` (and no `sun.net.client.default*Timeout` is set in the image), so a stalled mesh host blocks the resolve thread and the 3-attempt retry never fires; and on give-up it returns a `VisualType` with an empty OBJ, so the client sees a resolved type with no geometry and no error.
