### PR TITLE
Pin geppetto-client VFBv2.3.8.3 — flash the still-loading marker in the query results header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG geppettoSimulationRelease=VFBv2.1.0.3
 ARG geppettoDatasourceRelease=VFBv2.3.8.3
 ARG geppettoModelSwcRelease=v1.0.1
 ARG geppettoFrontendRelease=VFBv2.3.8.1
-ARG geppettoClientRelease=VFBv2.3.8.2
+ARG geppettoClientRelease=VFBv2.3.8.3
 ARG ukAcVfbGeppettoRelease=v2.2.5.2
 
 ARG mvnOpt="-Dhttps.protocols=TLSv1.2 -DskipTests --quiet -Pmaster"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,8 +1278,8 @@
       }
     },
     "@geppettoengine/geppetto-client": {
-      "version": "github:openworm/geppetto-client#b036daa9458f410307981aae4a1f1d0750756b0f",
-      "from": "github:openworm/geppetto-client#VFBv2.3.8.2",
+      "version": "github:openworm/geppetto-client#058ad7536c3ae170b63bdabbdf278f9b05d0dd59",
+      "from": "github:openworm/geppetto-client#VFBv2.3.8.3",
       "requires": {
         "@date-io/core": "1.3.6",
         "@fortawesome/fontawesome-svg-core": "^1.2.27",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.4.5",
     "@babel/plugin-transform-runtime": "^7.4.5",
-    "@geppettoengine/geppetto-client": "openworm/geppetto-client#VFBv2.3.8.2",
+    "@geppettoengine/geppetto-client": "openworm/geppetto-client#VFBv2.3.8.3",
     "@material-ui/icons": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@types/react-rnd": "^8.0.0",


### PR DESCRIPTION
Pin bump only; no code change in this repo.

## What changed (in geppetto-client VFBv2.3.8.3, off VFBv2.3.8.2)

While a query streams pages in, the results header shows the running total prefixed with `>` to mark it as a lower bound (`>30000`). The `>` was rendered in the same colour and weight as the number, so it read as part of the figure rather than as "still arriving".

It is now wrapped in `<span class="loading-more">` and flashed red (1s linear, dipping to 0.15 opacity), and is still dropped when the exact total lands. Under `prefers-reduced-motion: reduce` the animation is suppressed and the colour alone carries the meaning. If the span wrapper is ever removed the marker degrades to the plain `>`.

- `queryBuilder.js` — `appendResults` wraps the prefix; the strip-and-rewrite regex matches the wrapped form
- `query.less` — `.result-verbose-label span.loading-more` rule, `blinker` keyframes (alongside the existing `spin`), reduced-motion media query

## Pins bumped

- `package.json` → `openworm/geppetto-client#VFBv2.3.8.3`
- `package-lock.json` → `#058ad7536c3ae170b63bdabbdf278f9b05d0dd59`
- `Dockerfile` → `ARG geppettoClientRelease=VFBv2.3.8.3`

## How to test

Run a query with a large result set (e.g. NeuronsPartHere on a big neuropil) and watch the results header: the `>` should flash red beside the climbing count and disappear when the final total lands. Switching to another query mid-stream should leave the visible header alone, as before.
