### PR TITLE
Stop oversized meshes breaking the 3D viewer and the session

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,11 @@ VOLUME /tmp/error
 #SET TAG/BRANCH to use:
 ARG geppettoRelease=vfb_20200604_a
 ARG geppettoModelRelease=vfb_20200604_a
-ARG geppettoCoreRelease=VFBv2.3.8.1
+ARG geppettoCoreRelease=VFBv2.3.8.2
 ARG geppettoSimulationRelease=VFBv2.1.0.3
 ARG geppettoDatasourceRelease=VFBv2.3.8.3
 ARG geppettoModelSwcRelease=v1.0.1
-ARG geppettoFrontendRelease=VFBv2.3.8.1
+ARG geppettoFrontendRelease=VFBv2.3.8.2
 ARG geppettoClientRelease=VFBv2.3.8.3
 ARG ukAcVfbGeppettoRelease=v2.2.5.2
 
@@ -28,8 +28,12 @@ ARG VFB_OWL_SERVER_ARG=http://owl.virtualflybrain.org/kbs/vfb/
 ARG VFB_R_SERVER_ARG=http://r.virtualflybrain.org/ocpu/library/vfbr/R/vfb_nblast
 ARG SOLR_SERVER_ARG=https://solr.virtualflybrain.org/solr/ontology/select
 ARG googleAnalyticsSiteCode_ARG=G-K7DDZVVXM7
-# Largest volume_man.obj we will pull through the websocket; larger neurons render from SWC (VFB2 #455)
+# Largest volume_man.obj we will pull through the websocket; larger neurons render from SWC (VFB2 #455).
+# maxObjBytes is baked into the client bundle; VFB_MAX_OBJ_BYTES is read at runtime by the server-side guard.
 ARG maxObjBytes_ARG=157286400
+ARG VFB_MAX_OBJ_BYTES_ARG=157286400
+# Tomcat websocket blocking send timeout, ms (default 20000 is too short for large payloads)
+ARG VFB_WS_SEND_TIMEOUT_MS_ARG=300000
 ENV MAXSIZE=2G
 ARG finalBuild=true
 ENV USESSL=${finalBuild}
@@ -44,6 +48,8 @@ ENV VFB_R_SERVER=${VFB_R_SERVER_ARG}
 ENV SOLR_SERVER=${SOLR_SERVER_ARG}
 ENV googleAnalyticsSiteCode=${googleAnalyticsSiteCode_ARG}
 ENV maxObjBytes=${maxObjBytes_ARG}
+ENV VFB_MAX_OBJ_BYTES=${VFB_MAX_OBJ_BYTES_ARG}
+ENV VFB_WS_SEND_TIMEOUT_MS=${VFB_WS_SEND_TIMEOUT_MS_ARG}
 ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
 
 # Ensure root privileges for system-level kernel module configuration in build environments.

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ ARG VFB_OWL_SERVER_ARG=http://owl.virtualflybrain.org/kbs/vfb/
 ARG VFB_R_SERVER_ARG=http://r.virtualflybrain.org/ocpu/library/vfbr/R/vfb_nblast
 ARG SOLR_SERVER_ARG=https://solr.virtualflybrain.org/solr/ontology/select
 ARG googleAnalyticsSiteCode_ARG=G-K7DDZVVXM7
+# Largest volume_man.obj we will pull through the websocket; larger neurons render from SWC (VFB2 #455)
+ARG maxObjBytes_ARG=157286400
 ENV MAXSIZE=2G
 ARG finalBuild=true
 ENV USESSL=${finalBuild}
@@ -41,6 +43,7 @@ ENV VFB_OWL_SERVER=${VFB_OWL_SERVER_ARG}
 ENV VFB_R_SERVER=${VFB_R_SERVER_ARG}
 ENV SOLR_SERVER=${SOLR_SERVER_ARG}
 ENV googleAnalyticsSiteCode=${googleAnalyticsSiteCode_ARG}
+ENV maxObjBytes=${maxObjBytes_ARG}
 ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
 
 # Ensure root privileges for system-level kernel module configuration in build environments.

--- a/WEB-INF/spring/app-config.xml
+++ b/WEB-INF/spring/app-config.xml
@@ -90,7 +90,13 @@ http://www.eclipse.org/gemini/blueprint/schema/blueprint-compendium/gemini-bluep
 		<property name="queuingEnabled" value="true" />
 		<property name="maxQueueSize" value="5" />
 		<property name="discardMessagesIfQueueFull" value="false" />
-		<property name="compressionEnabled" value="false" />
+		<!-- Messages over minMessageLengthForCompression are gzipped and sent as a
+			binary frame with a leading zero byte; the client inflates them in
+			MessageSocket (pako.ungzip on messageBytes.subarray(1)) and parses the
+			result exactly as it would a text frame. OBJ meshes and large query
+			result sets gzip roughly 5-8x, which keeps them inside Tomcat's
+			blocking send timeout. See VFB2 #455. -->
+		<property name="compressionEnabled" value="true" />
 		<property name="minMessageLengthForCompression" value="20000" />
 
 		<!-- <property name="queuedMessageTypes"> <set> <value type="org.geppetto.frontend.messages.OutboundMessages">EXPERIMENT_UPDATE</value> 

--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -30,6 +30,20 @@ var GEPPETTO = require('geppetto');
 var Rnd = require('react-rnd').default;
 var modelJson = require('./configuration/VFBMain/layoutModel').modelJson;
 
+/*
+ * Largest volume_man.obj, in bytes, we are willing to pull through the websocket.
+ * Above this the neuron is rendered from its SWC skeleton instead. The transport
+ * has a hard ceiling of its own: the resolved model is JSON escaped twice before
+ * it is sent, so an OBJ much over 500 MB exceeds V8's maximum string length
+ * (536,870,888 characters) and cannot be held by the browser at any timeout.
+ * See VFB2 #455. Overridden at container start from the maxObjBytes environment
+ * variable when the image is built with runtime_build=true.
+ */
+var MAX_OBJ_BYTES = 157286400;
+
+/* Cache of URL -> byte length, so selecting the same neuron twice costs one HEAD. */
+var objSizeCache = {};
+
 class VFBMain extends React.Component {
 
   constructor (props) {
@@ -484,7 +498,6 @@ class VFBMain extends React.Component {
   }
 
   resolve3D (path, callback) {
-    var ImportType = require('@geppettoengine/geppetto-core/model/ImportType');
     var rootInstance = Instances.getInstance(path);
     GEPPETTO.SceneController.deselectAll();
 
@@ -579,12 +592,64 @@ class VFBMain extends React.Component {
       }
     }
 
+    /*
+     * A full mesh is preferred over the SWC skeleton, but only once we know it is
+     * small enough to survive the transport. Measure it first, then run the
+     * selection below; the measurement is cached and never blocks on failure.
+     */
+    var meshUrl = null;
+    try {
+      var objType = Instances[path].getType()[path + "_obj"].getType();
+      if (objType != undefined && objType.getUrl != undefined && (typeof objType.getUrl == "function") && objType.getUrl().includes("volume_man.obj")) {
+        meshUrl = objType.getUrl();
+      }
+    } catch (ignore) {
+      meshUrl = null;
+    }
+
+    if (meshUrl == null) {
+      this.selectAndResolve3D(path, callback, false);
+    } else {
+      this.withinObjSizeLimit(meshUrl, usable => this.selectAndResolve3D(path, callback, !usable));
+    }
+  }
+
+  /*
+   * HEAD the mesh and report whether it is within MAX_OBJ_BYTES. Fails open: if the
+   * request errors or the server omits content-length we keep today's behaviour and
+   * let the mesh through, rather than silently downgrading every neuron.
+   */
+  withinObjSizeLimit (url, done) {
+    if (objSizeCache[url] != undefined) {
+      done(objSizeCache[url] <= MAX_OBJ_BYTES);
+      return;
+    }
+    fetch(url, { method: "HEAD" }).then(response => {
+      var length = parseInt(response.headers.get("content-length"), 10);
+      if (isNaN(length)) {
+        console.warn("VFB: no content-length for " + url + ", loading the full mesh");
+        done(true);
+        return;
+      }
+      objSizeCache[url] = length;
+      if (length > MAX_OBJ_BYTES) {
+        console.warn("VFB: mesh " + url + " is " + length + " bytes, over the " + MAX_OBJ_BYTES + " byte limit; using the SWC skeleton instead");
+      }
+      done(length <= MAX_OBJ_BYTES);
+    }).catch(error => {
+      console.warn("VFB: could not measure " + url + " (" + error + "), loading the full mesh");
+      done(true);
+    });
+  }
+
+  selectAndResolve3D (path, callback, objTooLarge) {
+    var ImportType = require('@geppettoengine/geppetto-core/model/ImportType');
     var instance = undefined;
     var flagRendering = true;
     // check if we have a full mesh
     try {
       instance = Instances[path].getType()[path + "_obj"].getType();
-      if (instance != undefined && instance.getUrl != undefined && (typeof instance.getUrl == "function") && instance.getUrl().includes("volume_man.obj")) {
+      if (!objTooLarge && instance != undefined && instance.getUrl != undefined && (typeof instance.getUrl == "function") && instance.getUrl().includes("volume_man.obj")) {
         instance = Instances.getInstance(path + "." + path + "_obj");
         if ((!window[path][path + '_obj'].visible) && (typeof window[path][path + '_obj'].show == "function") && (flagRendering)) {
           window[path][path + '_obj'].show();
@@ -609,7 +674,7 @@ class VFBMain extends React.Component {
       }
     }
     // if no swc check if we have obj
-    if (instance == undefined) {
+    if (instance == undefined && !objTooLarge) {
       try {
         instance = Instances.getInstance(path + "." + path + "_obj");
         if ((!window[path][path + '_obj'].visible) && (typeof window[path][path + '_obj'].show == "function") && (flagRendering)) {

--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -100,6 +100,48 @@ function formatMeshSize (bytes) {
   return Math.round(bytes / (1024 * 1024)) + " MB";
 }
 
+/*
+ * The visibility controls in the term info, control panel, list viewer and focus
+ * term are configured as evaluated action strings, so they cannot import from here
+ * and reach the mesh size guard through these globals instead.
+ *
+ * These are assigned at module scope, NOT in componentDidMount. React mounts
+ * children before parents, so the term info button bar evaluates its showConditions
+ * before VFBMain has mounted; anything they depend on must already exist or the eval
+ * throws and the whole button bar renders empty.
+ *
+ * vfbObjOversized answers from the cache only so it can be called from a synchronous
+ * showCondition; it reports false until a measurement has been made.
+ * vfbGuardedObjResolve measures first, and is the one that must wrap any resolve.
+ */
+window.vfbObjOversized = function (instanceId) {
+  var url = objUrlForInstance(instanceId);
+  return url != null && objSizeCache[url] != undefined && objSizeCache[url] > MAX_OBJ_BYTES;
+};
+
+window.vfbExplainObjTooLarge = function (instanceId) {
+  var url = objUrlForInstance(instanceId);
+  var size = formatMeshSize(url == null ? undefined : objSizeCache[url]);
+  GEPPETTO.ModalFactory.infoDialog("Mesh too large for the browser",
+    size + ". Showing the 3D skeleton instead - use Download for the full mesh.");
+};
+
+window.vfbGuardedObjResolve = function (instanceId, proceed) {
+  var url = objUrlForInstance(instanceId);
+  if (url == null) {
+    proceed();
+    return;
+  }
+  withinObjSizeLimit(url, function (usable) {
+    if (usable) {
+      proceed();
+    } else {
+      window.vfbExplainObjTooLarge(instanceId);
+      GEPPETTO.ControlPanel.refresh();
+    }
+  });
+};
+
 class VFBMain extends React.Component {
 
   constructor (props) {
@@ -1751,43 +1793,6 @@ class VFBMain extends React.Component {
     window.addToQueryCallback = function (variableId, label) {
       this.addToQueryCallback(variableId, label)
     }.bind(this);
-
-    /*
-     * The visibility controls in the term info, control panel, list viewer and focus
-     * term are configured as evaluated action strings, so they cannot import from
-     * here and reach the mesh size guard through these globals instead.
-     *
-     * vfbObjOversized answers from the cache only so it can be called from a
-     * synchronous showCondition; it reports false until a measurement has been made.
-     * vfbGuardedObjResolve measures first, and is the one that must wrap any resolve.
-     */
-    window.vfbObjOversized = function (instanceId) {
-      var url = objUrlForInstance(instanceId);
-      return url != null && objSizeCache[url] != undefined && objSizeCache[url] > MAX_OBJ_BYTES;
-    };
-
-    window.vfbExplainObjTooLarge = function (instanceId) {
-      var url = objUrlForInstance(instanceId);
-      var size = formatMeshSize(url == null ? undefined : objSizeCache[url]);
-      GEPPETTO.ModalFactory.infoDialog("Mesh too large for the browser",
-        size + ". Showing the 3D skeleton instead - use Download for the full mesh.");
-    };
-
-    window.vfbGuardedObjResolve = function (instanceId, proceed) {
-      var url = objUrlForInstance(instanceId);
-      if (url == null) {
-        proceed();
-        return;
-      }
-      withinObjSizeLimit(url, function (usable) {
-        if (usable) {
-          proceed();
-        } else {
-          window.vfbExplainObjTooLarge(instanceId);
-          GEPPETTO.ControlPanel.refresh();
-        }
-      });
-    };
 
     window.resolve3D = function (externalID) {
       this.resolve3D(externalID, function (id) {

--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -624,10 +624,19 @@ class VFBMain extends React.Component {
       done(objSizeCache[url] <= MAX_OBJ_BYTES);
       return;
     }
-    fetch(url, { method: "HEAD" }).then(response => {
+    /*
+     * pdb stores these URLs with an http scheme, and the browser blocks an http
+     * request from an https page as mixed content before it reaches the network.
+     * The server side is unaffected, so only the measurement needs upgrading.
+     */
+    var measureUrl = url;
+    if (document.location.protocol == "https:" && measureUrl.indexOf("http://") == 0) {
+      measureUrl = "https://" + measureUrl.substring("http://".length);
+    }
+    fetch(measureUrl, { method: "HEAD" }).then(response => {
       var length = parseInt(response.headers.get("content-length"), 10);
       if (isNaN(length)) {
-        console.warn("VFB: no content-length for " + url + ", loading the full mesh");
+        console.warn("VFB: no content-length for " + measureUrl + ", loading the full mesh");
         done(true);
         return;
       }
@@ -637,7 +646,7 @@ class VFBMain extends React.Component {
       }
       done(length <= MAX_OBJ_BYTES);
     }).catch(error => {
-      console.warn("VFB: could not measure " + url + " (" + error + "), loading the full mesh");
+      console.warn("VFB: could not measure " + measureUrl + " (" + error + "), loading the full mesh");
       done(true);
     });
   }

--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -44,6 +44,62 @@ var MAX_OBJ_BYTES = 157286400;
 /* Cache of URL -> byte length, so selecting the same neuron twice costs one HEAD. */
 var objSizeCache = {};
 
+/*
+ * HEAD the mesh and report whether it is within MAX_OBJ_BYTES. Fails open: if the
+ * request errors or the server omits content-length we keep the previous behaviour
+ * and let the mesh through, rather than silently downgrading every neuron.
+ *
+ * pdb stores these URLs with an http scheme, and the browser blocks an http request
+ * from an https page as mixed content before it reaches the network. The server side
+ * is unaffected, so only the measurement needs upgrading.
+ */
+function withinObjSizeLimit (url, done) {
+  if (objSizeCache[url] != undefined) {
+    done(objSizeCache[url] <= MAX_OBJ_BYTES);
+    return;
+  }
+  var measureUrl = url;
+  if (document.location.protocol == "https:" && measureUrl.indexOf("http://") == 0) {
+    measureUrl = "https://" + measureUrl.substring("http://".length);
+  }
+  fetch(measureUrl, { method: "HEAD" }).then(response => {
+    var length = parseInt(response.headers.get("content-length"), 10);
+    if (isNaN(length)) {
+      console.warn("VFB: no content-length for " + measureUrl + ", loading the full mesh");
+      done(true);
+      return;
+    }
+    objSizeCache[url] = length;
+    if (length > MAX_OBJ_BYTES) {
+      console.warn("VFB: mesh " + url + " is " + length + " bytes, over the " + MAX_OBJ_BYTES + " byte limit; using the SWC skeleton instead");
+    }
+    done(length <= MAX_OBJ_BYTES);
+  }).catch(error => {
+    console.warn("VFB: could not measure " + measureUrl + " (" + error + "), loading the full mesh");
+    done(true);
+  });
+}
+
+/* Full-mesh URL for an instance, or null when it has no volume_man.obj. */
+function objUrlForInstance (instanceId) {
+  try {
+    var objType = Instances[instanceId].getType()[instanceId + "_obj"].getType();
+    if (objType != undefined && objType.getUrl != undefined && (typeof objType.getUrl == "function") && objType.getUrl().includes("volume_man.obj")) {
+      return objType.getUrl();
+    }
+  } catch (ignore) {
+    return null;
+  }
+  return null;
+}
+
+function formatMeshSize (bytes) {
+  if (bytes == undefined) {
+    return "unknown size";
+  }
+  return Math.round(bytes / (1024 * 1024)) + " MB";
+}
+
 class VFBMain extends React.Component {
 
   constructor (props) {
@@ -597,58 +653,13 @@ class VFBMain extends React.Component {
      * small enough to survive the transport. Measure it first, then run the
      * selection below; the measurement is cached and never blocks on failure.
      */
-    var meshUrl = null;
-    try {
-      var objType = Instances[path].getType()[path + "_obj"].getType();
-      if (objType != undefined && objType.getUrl != undefined && (typeof objType.getUrl == "function") && objType.getUrl().includes("volume_man.obj")) {
-        meshUrl = objType.getUrl();
-      }
-    } catch (ignore) {
-      meshUrl = null;
-    }
+    var meshUrl = objUrlForInstance(path);
 
     if (meshUrl == null) {
       this.selectAndResolve3D(path, callback, false);
     } else {
-      this.withinObjSizeLimit(meshUrl, usable => this.selectAndResolve3D(path, callback, !usable));
+      withinObjSizeLimit(meshUrl, usable => this.selectAndResolve3D(path, callback, !usable));
     }
-  }
-
-  /*
-   * HEAD the mesh and report whether it is within MAX_OBJ_BYTES. Fails open: if the
-   * request errors or the server omits content-length we keep today's behaviour and
-   * let the mesh through, rather than silently downgrading every neuron.
-   */
-  withinObjSizeLimit (url, done) {
-    if (objSizeCache[url] != undefined) {
-      done(objSizeCache[url] <= MAX_OBJ_BYTES);
-      return;
-    }
-    /*
-     * pdb stores these URLs with an http scheme, and the browser blocks an http
-     * request from an https page as mixed content before it reaches the network.
-     * The server side is unaffected, so only the measurement needs upgrading.
-     */
-    var measureUrl = url;
-    if (document.location.protocol == "https:" && measureUrl.indexOf("http://") == 0) {
-      measureUrl = "https://" + measureUrl.substring("http://".length);
-    }
-    fetch(measureUrl, { method: "HEAD" }).then(response => {
-      var length = parseInt(response.headers.get("content-length"), 10);
-      if (isNaN(length)) {
-        console.warn("VFB: no content-length for " + measureUrl + ", loading the full mesh");
-        done(true);
-        return;
-      }
-      objSizeCache[url] = length;
-      if (length > MAX_OBJ_BYTES) {
-        console.warn("VFB: mesh " + url + " is " + length + " bytes, over the " + MAX_OBJ_BYTES + " byte limit; using the SWC skeleton instead");
-      }
-      done(length <= MAX_OBJ_BYTES);
-    }).catch(error => {
-      console.warn("VFB: could not measure " + measureUrl + " (" + error + "), loading the full mesh");
-      done(true);
-    });
   }
 
   selectAndResolve3D (path, callback, objTooLarge) {
@@ -1740,6 +1751,43 @@ class VFBMain extends React.Component {
     window.addToQueryCallback = function (variableId, label) {
       this.addToQueryCallback(variableId, label)
     }.bind(this);
+
+    /*
+     * The visibility controls in the term info, control panel, list viewer and focus
+     * term are configured as evaluated action strings, so they cannot import from
+     * here and reach the mesh size guard through these globals instead.
+     *
+     * vfbObjOversized answers from the cache only so it can be called from a
+     * synchronous showCondition; it reports false until a measurement has been made.
+     * vfbGuardedObjResolve measures first, and is the one that must wrap any resolve.
+     */
+    window.vfbObjOversized = function (instanceId) {
+      var url = objUrlForInstance(instanceId);
+      return url != null && objSizeCache[url] != undefined && objSizeCache[url] > MAX_OBJ_BYTES;
+    };
+
+    window.vfbExplainObjTooLarge = function (instanceId) {
+      var url = objUrlForInstance(instanceId);
+      var size = formatMeshSize(url == null ? undefined : objSizeCache[url]);
+      GEPPETTO.ModalFactory.infoDialog("Mesh too large for the browser",
+        size + ". Showing the 3D skeleton instead - use Download for the full mesh.");
+    };
+
+    window.vfbGuardedObjResolve = function (instanceId, proceed) {
+      var url = objUrlForInstance(instanceId);
+      if (url == null) {
+        proceed();
+        return;
+      }
+      withinObjSizeLimit(url, function (usable) {
+        if (usable) {
+          proceed();
+        } else {
+          window.vfbExplainObjTooLarge(instanceId);
+          GEPPETTO.ControlPanel.refresh();
+        }
+      });
+    };
 
     window.resolve3D = function (externalID) {
       this.resolve3D(externalID, function (id) {

--- a/components/configuration/VFBMain/controlPanelConfiguration.js
+++ b/components/configuration/VFBMain/controlPanelConfiguration.js
@@ -98,7 +98,7 @@ var controlPanelConfig = {
       }
     },
     "volume_too_large": {
-      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj') && window.vfbObjOversized('$instance$')",
+      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj') && typeof window.vfbObjOversized == 'function' && window.vfbObjOversized('$instance$')",
       "id": "volume_too_large",
       "actions": ["window.vfbExplainObjTooLarge('$instance$')"],
       "icon": "fa-exclamation-triangle",
@@ -106,7 +106,7 @@ var controlPanelConfig = {
       "tooltip": "Mesh too large for the browser"
     },
     "visibility_obj": {
-      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj') && !window.vfbObjOversized('$instance$')",
+      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj') && !(typeof window.vfbObjOversized == 'function' && window.vfbObjOversized('$instance$'))",
       "condition": "(function() { var visible = false; if ($instance$.getType().$instance$_obj != undefined && $instance$.getType().$instance$_obj.getType().getMetaType() != GEPPETTO.Resources.IMPORT_TYPE && $instance$.$instance$_obj != undefined) { visible = GEPPETTO.SceneController.isVisible([$instance$.$instance$_obj]); } return visible; })()",
       "false": {
         "id": "visibility_obj",

--- a/components/configuration/VFBMain/controlPanelConfiguration.js
+++ b/components/configuration/VFBMain/controlPanelConfiguration.js
@@ -97,12 +97,20 @@ var controlPanelConfig = {
         "tooltip": "Hide"
       }
     },
+    "volume_too_large": {
+      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj') && window.vfbObjOversized('$instance$')",
+      "id": "volume_too_large",
+      "actions": ["window.vfbExplainObjTooLarge('$instance$')"],
+      "icon": "fa-exclamation-triangle",
+      "label": "Unavailable",
+      "tooltip": "Mesh too large for the browser"
+    },
     "visibility_obj": {
-      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj')",
+      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj') && !window.vfbObjOversized('$instance$')",
       "condition": "(function() { var visible = false; if ($instance$.getType().$instance$_obj != undefined && $instance$.getType().$instance$_obj.getType().getMetaType() != GEPPETTO.Resources.IMPORT_TYPE && $instance$.$instance$_obj != undefined) { visible = GEPPETTO.SceneController.isVisible([$instance$.$instance$_obj]); } return visible; })()",
       "false": {
         "id": "visibility_obj",
-        "actions": ["(function(){var color = $instance$.getColor(); var instance = Instances.getInstance('$instance$.$instance$_obj'); if (instance.getType().getMetaType() == GEPPETTO.Resources.IMPORT_TYPE) { var col = instance.getParent().getColor(); instance.getType().resolve(function() { instance.setColor(col); GEPPETTO.trigger('experiment:visibility_changed', instance); GEPPETTO.ControlPanel.refresh(); }); } else { if(GEPPETTO.SceneController.isInstancePresent(instance)) { GEPPETTO.SceneController.show([instance]); } else { GEPPETTO.SceneController.display(instance); instance.setColor(color);}}})()"],
+        "actions": ["(function(){var color = $instance$.getColor(); var instance = Instances.getInstance('$instance$.$instance$_obj'); if (instance.getType().getMetaType() == GEPPETTO.Resources.IMPORT_TYPE) { var col = instance.getParent().getColor(); window.vfbGuardedObjResolve('$instance$', function() { instance.getType().resolve(function() { instance.setColor(col); GEPPETTO.trigger('experiment:visibility_changed', instance); GEPPETTO.ControlPanel.refresh(); }); }); } else { if(GEPPETTO.SceneController.isInstancePresent(instance)) { GEPPETTO.SceneController.show([instance]); } else { GEPPETTO.SceneController.display(instance); instance.setColor(color);}}})()"],
         "icon": "gpt-shapehide",
         "label": "Hidden",
         "tooltip": "Show 3D Volume"

--- a/components/configuration/VFBTermInfo/VFBTermInfoConfiguration.js
+++ b/components/configuration/VFBTermInfo/VFBTermInfoConfiguration.js
@@ -58,7 +58,7 @@ const buttonBarConfiguration = {
       }
     },
     "volume_too_large": {
-      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj') && window.vfbObjOversized('$instance$')",
+      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj') && typeof window.vfbObjOversized == 'function' && window.vfbObjOversized('$instance$')",
       "id": "volume_too_large",
       "actions": ["window.vfbExplainObjTooLarge('$instance$')"],
       "icon": "fa-exclamation-triangle",
@@ -66,7 +66,7 @@ const buttonBarConfiguration = {
       "tooltip": "Mesh too large for the browser"
     },
     "visibility_obj": {
-      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj') && !window.vfbObjOversized('$instance$')",
+      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj') && !(typeof window.vfbObjOversized == 'function' && window.vfbObjOversized('$instance$'))",
       "condition": "(function() { var visible = false; if ($instance$.getType().$instance$_obj != undefined && $instance$.getType().$instance$_obj.getType().getMetaType() != GEPPETTO.Resources.IMPORT_TYPE && $instance$.$instance$_obj != undefined) { visible = GEPPETTO.SceneController.isVisible([$instance$.$instance$_obj]); } return visible; })()",
       "false": {
         "id": "visibility_obj",
@@ -117,6 +117,7 @@ const buttonBarControls = {
                        'color',
                        'visibility',
                        'visibility_obj',
+                       'volume_too_large',
                        'visibility_swc',
                        'geometryType_swc',
                        'zoom',

--- a/components/configuration/VFBTermInfo/VFBTermInfoConfiguration.js
+++ b/components/configuration/VFBTermInfo/VFBTermInfoConfiguration.js
@@ -57,12 +57,20 @@ const buttonBarConfiguration = {
         "tooltip": "Hide"
       }
     },
+    "volume_too_large": {
+      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj') && window.vfbObjOversized('$instance$')",
+      "id": "volume_too_large",
+      "actions": ["window.vfbExplainObjTooLarge('$instance$')"],
+      "icon": "fa-exclamation-triangle",
+      "label": "Unavailable",
+      "tooltip": "Mesh too large for the browser"
+    },
     "visibility_obj": {
-      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj')",
+      "showCondition": "$instance$.getType().hasVariable($instance$.getId() + '_obj') && !window.vfbObjOversized('$instance$')",
       "condition": "(function() { var visible = false; if ($instance$.getType().$instance$_obj != undefined && $instance$.getType().$instance$_obj.getType().getMetaType() != GEPPETTO.Resources.IMPORT_TYPE && $instance$.$instance$_obj != undefined) { visible = GEPPETTO.SceneController.isVisible([$instance$.$instance$_obj]); } return visible; })()",
       "false": {
         "id": "visibility_obj",
-        "actions": ["(function(){var color = $instance$.getColor();var instance = $instance$.$instance$_obj; if ($instance$.$instance$_obj == undefined || $instance$.getType().$instance$_obj.getType().getMetaType() == GEPPETTO.Resources.IMPORT_TYPE) { var col = $instance$.getColor(); $instance$.getType().$instance$_obj.getType().resolve(function() { var instance = Instances.getInstance('$instance$.$instance$_obj'); instance.setColor(col); GEPPETTO.trigger('experiment:visibility_changed', instance); GEPPETTO.ControlPanel.refresh(); }); } else { var instance = Instances.getInstance('$instance$.$instance$_obj'); if(GEPPETTO.SceneController.isInstancePresent(instance)) { GEPPETTO.SceneController.show([instance]); } else { GEPPETTO.SceneController.display(instance); instance.setColor(color);}}})()"],
+        "actions": ["(function(){var color = $instance$.getColor();var instance = $instance$.$instance$_obj; if ($instance$.$instance$_obj == undefined || $instance$.getType().$instance$_obj.getType().getMetaType() == GEPPETTO.Resources.IMPORT_TYPE) { var col = $instance$.getColor(); window.vfbGuardedObjResolve('$instance$', function() { $instance$.getType().$instance$_obj.getType().resolve(function() { var instance = Instances.getInstance('$instance$.$instance$_obj'); instance.setColor(col); GEPPETTO.trigger('experiment:visibility_changed', instance); GEPPETTO.ControlPanel.refresh(); }); }); } else { var instance = Instances.getInstance('$instance$.$instance$_obj'); if(GEPPETTO.SceneController.isInstancePresent(instance)) { GEPPETTO.SceneController.show([instance]); } else { GEPPETTO.SceneController.display(instance); instance.setColor(color);}}})()"],
         "icon": "gpt-shapehide",
         "label": "Hidden",
         "tooltip": "Enable 3D Volume"

--- a/dockerFiles/startup.sh
+++ b/dockerFiles/startup.sh
@@ -46,6 +46,9 @@ then
     echo "useSSL:${USESSL}"
     grep -rls '"useSsl"' $HOME/workspace/org.geppetto.frontend/
     grep -rls '"useSsl"' $HOME/workspace/org.geppetto.frontend/ | xargs sed -i "s@\"useSsl\"[[:space:]]*:[[:space:]]*\(true\|false\)@\"useSsl\": ${USESSL}@g"
+    echo "Max OBJ mesh bytes: ${maxObjBytes}"
+    grep -rls 'var MAX_OBJ_BYTES = ' $HOME/workspace/org.geppetto.frontend/src/main/webapp/components/VFBMain.js
+    grep -rls 'var MAX_OBJ_BYTES = ' $HOME/workspace/org.geppetto.frontend/src/main/webapp/components/VFBMain.js | xargs sed -i "s@var MAX_OBJ_BYTES = [0-9]*@var MAX_OBJ_BYTES = ${maxObjBytes}@g"
 
     set -e
 


### PR DESCRIPTION
Large-arbor neurons never rendered in the 3D viewer, and the failure took the rest of the session with it.

The mesh was read by the server, embedded in the model and pushed as a single uncompressed websocket frame. For APL_L (`VFB_jrmc3hpm`) that is 582,011,824 characters after the model JSON is escaped twice — past V8's 536,870,888 maximum string length, so the browser could not have held it at any timeout. The blocking send failed first, and because `sendText`/`sendBytes` clear the endpoint state only after a successful write, the connection was left in `TEXT_FULL_WRITING`/`BINARY_FULL_WRITING` permanently. Every later message on that session then failed; we observed it still failing 25 minutes later on an unrelated term-info fetch.

## Changes

- Websocket message compression enabled. The gzip path already existed on both sides and was simply switched off. Measured live: 251,210 → 17,534 (14.3x), 8,469,262 → 1,727,950 (4.9x).
- `resolve3D` measures the mesh before choosing it and falls back to the SWC skeleton above `maxObjBytes` (150 MB). The measurement upgrades the scheme to https first, since pdb stores these URLs as `http` and the browser blocks that as mixed content.
- The visibility controls called `resolve()` directly and bypassed that check. They now route through a guard, and where the size is known the toggle is replaced by a control reading "Mesh too large for the browser" with a dialog pointing at the OBJ download.
- Pins to `org.geppetto.core` VFBv2.3.8.2 (1.1.3), which refuses an oversized mesh server-side before reading it, and `org.geppetto.frontend` VFBv2.3.8.2 (1.0.3), which raises the blocking send timeout and closes a connection whose send has failed rather than leaving it unusable.
- `VFB_MAX_OBJ_BYTES` and `VFB_WS_SEND_TIMEOUT_MS` are read by the JVM at runtime; `maxObjBytes` is the client-side cap. Keep them equal — if the client cap were the higher of the two, users would see a working toggle for a mesh the server then refuses.

## Testing on v2-dev

APL_L renders from its skeleton (`volume.swc`, 29,572,631 → 2,135,435 compressed, sent in 436 ms). Meshes of 83–126 MB, which previously exceeded the 20 s send, now deliver in under 4 s:

```
83,410,518  -> 22,164,966   compress 6857 ms, send 3661 ms
126,415,682 -> 33,423,771   compress 8954 ms, send 4035 ms
108,309,954 -> 28,585,103   compress 7787 ms, send 3860 ms
```

No timeouts, no wedged connections, and the session stays usable afterwards. `org.geppetto.core 1.1.3` and `org.geppetto.frontend 1.0.3` both start cleanly.

A first attempt at the size guard broke the term info button bar: the guard globals were assigned in `componentDidMount`, React mounts children before parents, and `ButtonBarComponent`'s unguarded `eval` of the `showCondition` threw before they existed — emptying the whole bar rather than dropping one control. Fixed by moving them to module scope and hardening both conditions with a `typeof` check. Worth knowing for anyone adding a `showCondition` here.

## Not addressed here

The meshes are still undecimated, MaleCNS has no `volume.obj` fallback, and the data host serves `.obj` without gzip. Tracked in #456.

Closes #455.
