### PR TITLE
Repin geppetto-client to VFBv2.3.8.4 (malformed-frame guard)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,8 +1278,8 @@
       }
     },
     "@geppettoengine/geppetto-client": {
-      "version": "github:openworm/geppetto-client#058ad7536c3ae170b63bdabbdf278f9b05d0dd59",
-      "from": "github:openworm/geppetto-client#VFBv2.3.8.3",
+      "version": "github:openworm/geppetto-client#547a36407167af0ffba54afa1ed26152932dad56",
+      "from": "github:openworm/geppetto-client#VFBv2.3.8.4",
       "requires": {
         "@date-io/core": "1.3.6",
         "@fortawesome/fontawesome-svg-core": "^1.2.27",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.4.5",
     "@babel/plugin-transform-runtime": "^7.4.5",
-    "@geppettoengine/geppetto-client": "openworm/geppetto-client#VFBv2.3.8.3",
+    "@geppettoengine/geppetto-client": "openworm/geppetto-client#VFBv2.3.8.4",
     "@material-ui/icons": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@types/react-rnd": "^8.0.0",


### PR DESCRIPTION
Bumps @geppettoengine/geppetto-client to openworm/geppetto-client@547a364 (branch VFBv2.3.8.4), which guards MessageSocket.processBinaryMessage against empty/corrupt binary WebSocket frames instead of silently downloading them as a blank file, and reports the failure through vfbReportWebsocketFailure (added in the previous commit on this branch) when it happens. npm ci resolves git dependencies by the exact commit SHA in package-lock.json, so the package.json branch bump alone would not have shipped this.

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
