### PR TITLE
Report truncated WebSocket payloads instead of throwing uncaught

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,8 +1278,8 @@
       }
     },
     "@geppettoengine/geppetto-client": {
-      "version": "github:openworm/geppetto-client#547a36407167af0ffba54afa1ed26152932dad56",
-      "from": "github:openworm/geppetto-client#VFBv2.3.8.4",
+      "version": "github:openworm/geppetto-client#ca0c7ea4a3697b3aaaaabfc7005028981f55f9b7",
+      "from": "github:openworm/geppetto-client#VFBv2.3.8.5",
       "requires": {
         "@date-io/core": "1.3.6",
         "@fortawesome/fontawesome-svg-core": "^1.2.27",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.4.5",
     "@babel/plugin-transform-runtime": "^7.4.5",
-    "@geppettoengine/geppetto-client": "openworm/geppetto-client#VFBv2.3.8.4",
+    "@geppettoengine/geppetto-client": "openworm/geppetto-client#VFBv2.3.8.5",
     "@material-ui/icons": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@types/react-rnd": "^8.0.0",


### PR DESCRIPTION
Fixes the failure observed on v2-dev in Safari 26: the app loads to an empty viewer ("Template not loaded yet.", no Term Info, no layers) with no error dialog and no actionable console output.

**Cause.** On a failing connection a frame arrives intact and gzip-decompresses cleanly, but the JSON inside it is truncated mid-string. `MessageReassembler.processMessage` catches that first parse failure, logs "Error processing message", and returns the raw string as a not-JSON fallback. `parseAndNotify` then parses that same string a second time and throws uncaught. The throw aborts `parseAndNotify` before it notifies any handler or resolves the pending callback, so the application waits indefinitely for a reply that already arrived broken. The socket then closes 1006 and reconnects, repeating the cycle.

The reassembler's fallback is only valid for a message that was never JSON; for a truncated payload it guarantees a second, fatal parse. This is a client bug independent of the browser - Safari's truncation is what exposes it.

**Change.** Guard the re-parse in `parseAndNotify`: discard the message, log its length, and report via `vfbReportWebsocketFailure` so the user is told the connection is failing instead of being left on a blank screen. Also log payload size in the reassembler's catch so a truncated payload can be told apart from a genuinely non-JSON message.

Repins `@geppettoengine/geppetto-client` to `openworm/geppetto-client@ca0c7ea` (branch `VFBv2.3.8.5`) in both `package.json` and `package-lock.json`, since `npm ci` resolves by the exact SHA.

**Note on the earlier guards.** The empty-frame and malformed-frame guards added in #1715/#1716 sit one layer too early to catch this: at the point of failure `socketStatus` is `OPEN` and a client ID has been assigned, so the conditions keyed on those never match. Verified against the live bundle and by calling `window.vfbReportWebsocketFailure()` manually, which does show the dialog correctly.

**Not addressed here:** `MessageSocket.attempts` is reset on every transport `onopen`, so during a reconnect flap the "reconnection exhausted" branch stays unreachable - worth a separate fix. Nor does this address *why* payloads are truncated; if large messages are being cut in flight, the cure is server/proxy-side on v2-dev rather than client-side reporting.
