### PR TITLE
Recover automatically from broken WebSocket compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ ARG geppettoCoreRelease=VFBv2.3.8.2
 ARG geppettoSimulationRelease=VFBv2.1.0.3
 ARG geppettoDatasourceRelease=VFBv2.3.8.3
 ARG geppettoModelSwcRelease=v1.0.1
-ARG geppettoFrontendRelease=VFBv2.3.8.2
-ARG geppettoClientRelease=VFBv2.3.8.3
+ARG geppettoFrontendRelease=VFBv2.3.8.3
+ARG geppettoClientRelease=VFBv2.3.8.6
 ARG ukAcVfbGeppettoRelease=v2.2.5.2
 
 ARG mvnOpt="-Dhttps.protocols=TLSv1.2 -DskipTests --quiet -Pmaster"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG geppettoSimulationRelease=VFBv2.1.0.3
 ARG geppettoDatasourceRelease=VFBv2.3.8.3
 ARG geppettoModelSwcRelease=v1.0.1
 ARG geppettoFrontendRelease=VFBv2.3.8.3
-ARG geppettoClientRelease=VFBv2.3.8.6
+ARG geppettoClientRelease=VFBv2.3.8.7
 ARG ukAcVfbGeppettoRelease=v2.2.5.2
 
 ARG mvnOpt="-Dhttps.protocols=TLSv1.2 -DskipTests --quiet -Pmaster"

--- a/WEB-INF/web.ejs
+++ b/WEB-INF/web.ejs
@@ -59,6 +59,24 @@
         <url-pattern>/TestServlet</url-pattern>
     </servlet-mapping>
 
+    <!--
+        Lets a client that has detected broken WebSocket compression reconnect
+        with nodeflate=1, which makes the server decline permessage-deflate for
+        that one handshake. Declared here rather than added programmatically so
+        that it runs before the container's own WebSocket upgrade filter, which
+        is what allows it to affect extension negotiation.
+    -->
+    <filter>
+        <filter-name>WebsocketCompressionFilter</filter-name>
+        <filter-class>org.geppetto.frontend.controllers.WebsocketCompressionFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>WebsocketCompressionFilter</filter-name>
+        <url-pattern>/GeppettoServlet</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+    </filter-mapping>
+
     <filter>
         <filter-name>ShiroFilter</filter-name>
         <filter-class>org.apache.shiro.web.servlet.ShiroFilter</filter-class>

--- a/components/VFBMain.js
+++ b/components/VFBMain.js
@@ -2018,13 +2018,15 @@ class VFBMain extends React.Component {
     }
 
     /*
-     * The application is unusable without its WebSocket connection. Some
-     * browsers fail to establish it at all (seen with recent Safari releases,
-     * notably when iCloud Private Relay is enabled) while the server side is
-     * healthy. When the socket has never completed its first handshake, warn
-     * the user that this is likely a browser compatibility issue and report
-     * the failure to Google Analytics at maximum severity, instead of
-     * reloading in a loop.
+     * The application is unusable without its WebSocket connection. This is
+     * the last-resort hand fallback: the client recovers from the causes it
+     * can identify on its own (a browser that mishandles permessage-deflate
+     * reconnects uncompressed), so anything reaching here is a failure we
+     * cannot work around - a browser without WebSocket support, a blocked or
+     * unstable connection, or a fault we have not identified. Keep the
+     * wording general: it must read sensibly for any of those, so it names no
+     * particular browser or setting. Report to Google Analytics at maximum
+     * severity rather than reloading in a loop.
      */
     var websocketFailureReported = false;
     var reportWebsocketFailure = function (context) {
@@ -2042,7 +2044,7 @@ class VFBMain extends React.Component {
         'page:' + (window.location.pathname + window.location.search)
       ].join(' | ');
       // Routed to GA as an errorlog event by the console.error override above
-      console.error('WebSocket connection could not be established: ' + details);
+      console.error('WebSocket connection failed: ' + details);
       if (typeof gtag === 'function') {
         // GA4 exception hit with fatal set - the highest severity GA offers
         gtag('event', 'exception', {
@@ -2051,12 +2053,11 @@ class VFBMain extends React.Component {
         });
       }
       window.ga('vfb.send', 'event', 'websocket-connection-failed', 'websocket-error', details);
-      GEPPETTO.ModalFactory.infoDialog('Unable to connect to the Virtual Fly Brain server',
-        'Your browser could not establish the WebSocket connection that Virtual Fly Brain requires to load data. '
-        + 'This usually indicates a browser compatibility issue rather than a problem with the service; some recent '
-        + 'Safari releases are known to have WebSocket connection problems, particularly when iCloud Private Relay is enabled.'
-        + '<br/><br/>Please try reloading the page, using a different browser such as Chrome, Firefox or Edge, or, if you are '
-        + 'using Safari with iCloud Private Relay, temporarily disabling Private Relay and reloading.'
+      GEPPETTO.ModalFactory.infoDialog('Unable to load data from the Virtual Fly Brain server',
+        'Virtual Fly Brain needs a WebSocket connection to load its data, and that connection could not be established '
+        + 'or was interrupted. This is usually a browser or network problem rather than a fault with the service.'
+        + '<br/><br/>Please try reloading the page. If the problem persists, try a different browser such as Chrome, '
+        + 'Firefox or Edge, or a different network - some corporate firewalls and proxies block WebSocket connections.'
         + '<br/><br/>This failure has been reported automatically to help us investigate.');
     };
     window.vfbReportWebsocketFailure = reportWebsocketFailure;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,8 +1278,8 @@
       }
     },
     "@geppettoengine/geppetto-client": {
-      "version": "github:openworm/geppetto-client#4156d1cd885939fa3bd0cd727a0c988ca2ee6fff",
-      "from": "github:openworm/geppetto-client#VFBv2.3.8.6",
+      "version": "github:openworm/geppetto-client#c15efb217dbdb9402550a5958e93946077fb7c78",
+      "from": "github:openworm/geppetto-client#VFBv2.3.8.7",
       "requires": {
         "@date-io/core": "1.3.6",
         "@fortawesome/fontawesome-svg-core": "^1.2.27",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,8 +1278,8 @@
       }
     },
     "@geppettoengine/geppetto-client": {
-      "version": "github:openworm/geppetto-client#ca0c7ea4a3697b3aaaaabfc7005028981f55f9b7",
-      "from": "github:openworm/geppetto-client#VFBv2.3.8.5",
+      "version": "github:openworm/geppetto-client#4156d1cd885939fa3bd0cd727a0c988ca2ee6fff",
+      "from": "github:openworm/geppetto-client#VFBv2.3.8.6",
       "requires": {
         "@date-io/core": "1.3.6",
         "@fortawesome/fontawesome-svg-core": "^1.2.27",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.4.5",
     "@babel/plugin-transform-runtime": "^7.4.5",
-    "@geppettoengine/geppetto-client": "openworm/geppetto-client#VFBv2.3.8.5",
+    "@geppettoengine/geppetto-client": "openworm/geppetto-client#VFBv2.3.8.6",
     "@material-ui/icons": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@types/react-rnd": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.4.5",
     "@babel/plugin-transform-runtime": "^7.4.5",
-    "@geppettoengine/geppetto-client": "openworm/geppetto-client#VFBv2.3.8.6",
+    "@geppettoengine/geppetto-client": "openworm/geppetto-client#VFBv2.3.8.7",
     "@material-ui/icons": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@types/react-rnd": "^8.0.0",


### PR DESCRIPTION
Fixes VFB failing to load in Safari and on iOS, where the application sat on empty viewers ("Template not loaded yet.") with no explanation, and in one variant deposited an empty file named `download` in the user's Downloads folder.

**Cause.** `permessage-deflate` WebSocket compression. Apple's NSURLSession stack — used by Safari and by every browser on iOS — negotiates the extension and then fails to inflate correctly, so a frame arrives, decompresses to truncated JSON, and the connection drops. Compression was enabled server-side recently to help with large transfers; the incompatibility itself is long-standing and documented, and there is no client-side way to decline the extension, so the server has to.

**Fix.** When a frame cannot be read, the client checks `socket.extensions`. If compression really was negotiated it records that this browser mishandles it, reconnects with `nodeflate=1`, and recovers silently; a new server-side filter hides the `Sec-WebSocket-Extensions` header for that handshake so the extension is declined. Compression is retained for every client that handles it correctly, including large transfers. The verdict is evidence-based rather than a user-agent guess, persists so returning visitors skip the broken path, and expires after 30 days so a fixed browser earns compression back.

**Also fixed.** The reconnection budget was reset whenever the transport opened, so a connection that opened and died repeatedly never accumulated a count, never reached the retry limit, and retried in silence indefinitely with nothing shown to the user. It is now reset only after a connection has stayed open for 30 seconds.

The failure dialog is reworded to suit any remaining cause — no browser or setting is named — since the client now recovers on its own from the cause we identified.

**Pins:** `geppetto-client` `VFBv2.3.8.5` → `VFBv2.3.8.7`; `org.geppetto.frontend` `VFBv2.3.8.2` → `VFBv2.3.8.3` (carries the filter). The `geppettoClientRelease` Dockerfile ARG, which had drifted from `package.json`, is realigned.

**Verified on v2-dev:** plain handshake negotiates `permessage-deflate;client_max_window_bits=15`; `?nodeflate=1` declines it. Safari loads, Chrome unaffected.
