### PR TITLE
Pin datasources and frontend to VFBv2.3.8.4 (memory fixes for #458 in VFB2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ ARG geppettoRelease=vfb_20200604_a
 ARG geppettoModelRelease=vfb_20200604_a
 ARG geppettoCoreRelease=VFBv2.3.8.2
 ARG geppettoSimulationRelease=VFBv2.1.0.3
-ARG geppettoDatasourceRelease=VFBv2.3.8.3
+ARG geppettoDatasourceRelease=VFBv2.3.8.4
 ARG geppettoModelSwcRelease=v1.0.1
-ARG geppettoFrontendRelease=VFBv2.3.8.3
+ARG geppettoFrontendRelease=VFBv2.3.8.4
 ARG geppettoClientRelease=VFBv2.3.8.8
 ARG ukAcVfbGeppettoRelease=v2.2.5.2
 


### PR DESCRIPTION
Picks up the two memory fixes for the container OOM/restart cycle (VirtualFlyBrain/VFB2#458):

`org.geppetto.datasources` VFBv2.3.8.4 (1.0.8) removes the static JVM-wide query-results cache in `ADataSourceService`. It retained up to 11 full `QueryResults` object graphs across all sessions and users for the container's lifetime, with an `EcoreUtil.copy` deep copy on insert and on every hit — large results displaced small ones, so baseline memory ratcheted upward. Query results are no longer cached server-side beyond the requesting session; the v3-cached nginx layer remains the cache.

`org.geppetto.frontend` VFBv2.3.8.4 (1.0.4) bounds the retained-session-manager map at 32 records with oldest-first eviction and purges it on every abnormal close rather than only when a new connection arrives. The 5-minute cookie-sticky resume window is unchanged.

To test: build the image from this branch, run a session with several large queries (e.g. a 20k-row connectivity query), and confirm the container RSS baseline no longer steps up after each large query; reconnect behaviour within 5 minutes should be unchanged.
