### PR TITLE
development -> master: Fix Geppetto memory growth and post-reconnect null-user errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ ARG geppettoRelease=vfb_20200604_a
 ARG geppettoModelRelease=vfb_20200604_a
 ARG geppettoCoreRelease=VFBv2.3.8.2
 ARG geppettoSimulationRelease=VFBv2.1.0.3
-ARG geppettoDatasourceRelease=VFBv2.3.8.3
+ARG geppettoDatasourceRelease=VFBv2.3.8.4
 ARG geppettoModelSwcRelease=v1.0.1
-ARG geppettoFrontendRelease=VFBv2.3.8.3
+ARG geppettoFrontendRelease=VFBv2.3.8.4
 ARG geppettoClientRelease=VFBv2.3.8.8
 ARG ukAcVfbGeppettoRelease=v2.2.5.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG geppettoSimulationRelease=VFBv2.1.0.3
 ARG geppettoDatasourceRelease=VFBv2.3.8.3
 ARG geppettoModelSwcRelease=v1.0.1
 ARG geppettoFrontendRelease=VFBv2.3.8.3
-ARG geppettoClientRelease=VFBv2.3.8.7
+ARG geppettoClientRelease=VFBv2.3.8.8
 ARG ukAcVfbGeppettoRelease=v2.2.5.2
 
 ARG mvnOpt="-Dhttps.protocols=TLSv1.2 -DskipTests --quiet -Pmaster"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,8 +1278,8 @@
       }
     },
     "@geppettoengine/geppetto-client": {
-      "version": "github:openworm/geppetto-client#c15efb217dbdb9402550a5958e93946077fb7c78",
-      "from": "github:openworm/geppetto-client#VFBv2.3.8.7",
+      "version": "github:openworm/geppetto-client#e4e600244e1adef5d9c4f73f4be2e0dba593baa1",
+      "from": "github:openworm/geppetto-client#VFBv2.3.8.8",
       "requires": {
         "@date-io/core": "1.3.6",
         "@fortawesome/fontawesome-svg-core": "^1.2.27",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.4.5",
     "@babel/plugin-transform-runtime": "^7.4.5",
-    "@geppettoengine/geppetto-client": "openworm/geppetto-client#VFBv2.3.8.7",
+    "@geppettoengine/geppetto-client": "openworm/geppetto-client#VFBv2.3.8.8",
     "@material-ui/icons": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@types/react-rnd": "^8.0.0",


### PR DESCRIPTION
## Release details

Two fixes for the Geppetto v2 container OOM/restart cycle (VirtualFlyBrain/VFB2#458), plus a client pin bump that resolves a related symptom seen in the same logs.

**Remove the static cross-session query-results cache** — `org.geppetto.datasources` VFBv2.3.8.4. `ADataSourceService` held a JVM-wide cache of full query results shared across every session and user, with no expiry and a deep copy on every insert and hit. Query results are no longer cached server-side beyond the requesting session; the existing v3-cached nginx layer remains the cache.

**Bound retained session managers** — `org.geppetto.frontend` VFBv2.3.8.4. On an abnormal disconnect the server stashes the session's model for up to 5 minutes so a reconnect can resume it. The map had no size limit and was only swept when a new connection arrived. Now bounded at 32 records with oldest-first eviction, purged on every disconnect. The 5-minute resume window itself is unchanged.

**`geppetto-client` VFBv2.3.8.8** — carries the client's connection id across a reconnect after a compression failure. Without it the resume request had an undefined id, which the server couldn't match, logging `other.getUser() returned null` and dropping the connection — the repeating errors and climbing connection ids seen in production after v2.2.8.11.

Verified on v2-dev.
